### PR TITLE
Add code to exclude stacks based on an environment variable

### DIFF
--- a/ci/add_collection_resources.sh
+++ b/ci/add_collection_resources.sh
@@ -86,7 +86,11 @@ if [ -z $BUILD_ALL ]
 then
    release_name=$stack_id-v$stack_version
 else
-   release_name=$BUILD_ALL
+    if [ -f $base_dir/VERSION ]; then
+        release_name=$(cat $base_dir/VERSION)
+    else
+        release_name=$BUILD_ALL
+    fi
 fi
 
 if [ -f $collection ]

--- a/ci/list.sh
+++ b/ci/list.sh
@@ -47,7 +47,7 @@ else
                 then
                     var=`echo ${stack_exists#"$base_dir/"}`
                     repo_stack=`awk '{split($1, a, "/*"); print a[1]"/"a[2]}' <<< $var`
-                    if [ $TRAVIS_TAG ] && [ -z $BUILD_ALL ] && [[ $repo_stack != */$stack_id ]]
+                    if [ -z $BUILD_ALL ] && [ $TRAVIS_TAG ] && [[ $repo_stack != */$stack_id ]]
                     then
                         continue;
                     fi


### PR DESCRIPTION
This add code to do the following:

1. Utilise an environment variable, EXCLUDED_STACKS, to exclude a repo/stack from the build
2. Set the release_version based on the content of the VERSION file is the BUILD_ALL environment variable is set (with some content). If the VERSION file does not exist then the release_version will be set to the value of BUILD_ALL.
3. Some minor refactoring of the code to make it easier to read.

Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

### Related Issues:
https://github.com/kabanero-io/kabanero-collection/issues/47