### PR TITLE
Use UBI base image for nodejs stack

### DIFF
--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -1,4 +1,8 @@
-FROM node:10
+FROM registry.access.redhat.com/ubi8/nodejs-10
+
+USER root
+RUN yum install python2 -y
+RUN ln -s /usr/bin/python2 /usr/bin/python
 
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/node_modules
@@ -7,7 +11,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_INSTALL="npm install && npm audit fix"
+ENV APPSODY_INSTALL="npm install"
 
 ENV APPSODY_RUN="npm start --node-options --require=appmetrics-dash/attach"
 ENV APPSODY_RUN_ON_CHANGE="npm start --node-options --require=appmetrics-dash/attach"
@@ -24,7 +28,7 @@ ENV APPSODY_TEST_KILL=false
 COPY ./project /project
 
 WORKDIR /project
-RUN npm install && npm audit fix
+RUN npm install
 
 WORKDIR /project/user-app
 

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -1,32 +1,21 @@
-# Install the app dependencies in a full Node docker image
-FROM node:10
+FROM registry.access.redhat.com/ubi8/nodejs-10
+
+USER root
 
 # Install OS updates
-RUN apt-get update \
- && apt-get dist-upgrade -y \
- && apt-get clean \
+RUN yum upgrade -y \
+ && yum clean packages \
  && echo 'Finished installing dependencies'
+
+ RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
 # Install user-app dependencies
 WORKDIR "/project/user-app"
 COPY ./user-app/package*.json ./
 RUN npm install --production
-WORKDIR "/project/user-app/node_modules"
 
-# Copy the dependencies into a slim Node docker image
-FROM node:10-slim
-
-# Install OS updates
-RUN apt-get update \
- && apt-get dist-upgrade -y \
- && apt-get clean \
- && echo 'Finished installing dependencies'
-
-# Copy the project
-COPY --chown=node:node . /project
-
-# Copy all dependencies
-COPY --chown=node:node --from=0 /project/user-app/node_modules /project/user-app/node_modules
+RUN chown -R node:node /project
 
 WORKDIR "/project/user-app"
 


### PR DESCRIPTION
This PR updates the nodejs collection to use Redhat UBI base images.