### PR TITLE
Use UBI base image for nodejs-express collection

### DIFF
--- a/incubator/nodejs-express/collection.yaml
+++ b/incubator/nodejs-express/collection.yaml
@@ -1,0 +1,5 @@
+default-image: nodejs-express
+default-pipeline: default
+images:
+- id: nodejs-express
+  image: kabanero/nodejs-express:0.2

--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -1,4 +1,8 @@
-FROM appsody/nodejs:0.2
+FROM registry.access.redhat.com/ubi8/nodejs-10
+
+USER root
+RUN yum install python2 -y
+RUN ln -s /usr/bin/python2 /usr/bin/python
 
 ENV APPSODY_MOUNTS=/:/project/user-app
 ENV APPSODY_DEPS=/project/user-app/node_modules
@@ -7,7 +11,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_INSTALL="npm install --prefix user-app && npm audit fix --prefix user-app"
+ENV APPSODY_INSTALL="npm install --prefix user-app"
 
 ENV APPSODY_RUN="npm start"
 ENV APPSODY_RUN_ON_CHANGE="npm start"
@@ -23,7 +27,7 @@ ENV APPSODY_TEST_KILL=false
 
 COPY ./project /project
 WORKDIR /project
-RUN npm install && npm audit fix
+RUN npm install
 
 ENV PORT=3000
 ENV NODE_PATH=/project/user-app/node_modules

--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -1,11 +1,17 @@
-# Install the app dependencies in a full Node docker image
-FROM node:10
+FROM registry.access.redhat.com/ubi8/nodejs-10
+
+USER root
 
 # Install OS updates
-RUN apt-get update \
- && apt-get dist-upgrade -y \
- && apt-get clean \
+RUN yum upgrade -y \
+ && yum clean packages \
  && echo 'Finished installing dependencies'
+
+ RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+ RUN yum install python2 -y
+ RUN ln -s /usr/bin/python2 /usr/bin/python
 
 # Install stack dependencies
 WORKDIR /project
@@ -16,23 +22,6 @@ RUN npm install --production
 WORKDIR /project/user-app
 COPY ./user-app/package*.json ./
 RUN npm install --production
-WORKDIR /project/user-app/node_modules
-
-# Copy the dependencies into a slim Node docker image
-FROM node:10-slim
-
-# Install OS updates
-RUN apt-get update \
- && apt-get dist-upgrade -y \
- && apt-get clean \
- && echo 'Finished installing dependencies'
-
-# Copy the project
-COPY --chown=node:node . /project
-
-# Copy all dependencies
-COPY --chown=node:node --from=0 /project/node_modules /project/node_modules
-COPY --chown=node:node --from=0 /project/user-app/node_modules /project/user-app/node_modules
 
 WORKDIR /project
 


### PR DESCRIPTION
This PR updates the nodejs-express collection to use Redhat UBI base images.