### PR TITLE
Use Python3 instead of Python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ services:
   - docker
 
 script:
+  - pyenv global 3.6
+  - pip3 install pyyaml
   - . ./ci/build.sh .
 
 # note before_deploy will run before each deploy provider

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -17,4 +17,4 @@ fi
 . $base_dir/ci/package.sh $base_dir
 . $base_dir/ci/test.sh $base_dir
 
-python $base_dir/ci/create_codewind_index.py $base_dir
+python3 $base_dir/ci/create_codewind_index.py $base_dir

--- a/ci/create_codewind_index.py
+++ b/ci/create_codewind_index.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import yaml
 import json
@@ -14,7 +14,7 @@ assets_dir = base_dir + "/assets/"
 
 for file in os.listdir(assets_dir):
     if fnmatch.fnmatch(file, '*index.yaml'):
-        with open(assets_dir + file, 'r') as yamlFile, open(assets_dir + os.path.splitext(file)[0] + ".json", 'w') as jsonFile:
+        with open(assets_dir + file, 'r') as yamlFile, open(assets_dir + os.path.splitext(file)[0] + ".json", 'wb') as jsonFile:
             try:
                 doc = yaml.safe_load(yamlFile)
                 list = []


### PR DESCRIPTION
Python2 is EOL in 2020.

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->