### PR TITLE
Use UBI base image for java-microprofile stack

### DIFF
--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,14 +1,47 @@
-FROM adoptopenjdk/openjdk8-openj9
+FROM registry.access.redhat.com/ubi7/ubi
+
+RUN yum upgrade -y \
+   && yum clean packages \
+   && echo 'Finished installing dependencies'
 
 USER root
-RUN  apt-get -qq update \
-  && apt-get -qq install -y curl maven \
-  && DEBIAN_FRONTEND=noninteractive apt-get -qq upgrade -y \
-  && apt-get -qq clean \
-  && rm -rf /tmp/* /var/lib/apt/lists/*
+RUN yum install -y curl
 
 COPY ./project /project
 WORKDIR /project/
+
+#Install openjdk
+ENV JAVA_VERSION jdk8u222-b10_openj9-0.15.1
+
+RUN set -eux; \
+   ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
+   BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
+   curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+   mkdir -p /opt/java/openjdk; \
+   cd /opt/java/openjdk; \
+   tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+   rm -rf /tmp/openjdk.tar.gz;
+
+   ENV JAVA_HOME=/opt/java/openjdk \
+   PATH="/opt/java/openjdk/bin:$PATH"
+   ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
+
+# Maven install
+ARG MAVEN_VERSION=3.6.1
+ARG USER_HOME_DIR="/root"
+ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN mkdir -p /mvn/repository
 RUN mvn -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
@@ -18,9 +51,9 @@ WORKDIR /project/user-app
 ENV APPSODY_MOUNTS="~/.m2/repository:/mvn/repository;src:/project/user-app/src;pom.xml:/project/user-app/pom.xml"
 ENV APPSODY_DEPS=
 
-# ENV APPSODY_WATCH_DIR=/project/src
-# ENV APPSODY_WATCH_IGNORE_DIR=
-# ENV APPSODY_WATCH_REGEX=""
+ENV APPSODY_WATCH_DIR=/project/user-app
+ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/target
+ENV APPSODY_WATCH_REGEX="^.*(.xml|.java|.properties)$"
 
 ENV APPSODY_INSTALL="../validate.sh && mvn -Dmaven.repo.local=/mvn/repository install -DskipTests"
 

--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -1,11 +1,49 @@
-FROM adoptopenjdk/openjdk8-openj9
+FROM registry.access.redhat.com/ubi7/ubi
 
-RUN apt-get update && \
-    apt-get install -y maven unzip
+RUN yum upgrade -y \
+   && yum clean packages \
+   && mkdir -p /mvn/repository \
+   && echo 'Finished installing dependencies'
+
+USER root
+RUN yum install -y unzip curl ca-certificates
+
+#Install openjdk
+ENV JAVA_VERSION jdk8u222-b10_openj9-0.15.1
+
+RUN set -eux; \
+   ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
+   BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
+   curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+   mkdir -p /opt/java/openjdk; \
+   cd /opt/java/openjdk; \
+   tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+   rm -rf /tmp/openjdk.tar.gz;
+
+   ENV JAVA_HOME=/opt/java/openjdk \
+   PATH="/opt/java/openjdk/bin:$PATH"
+   ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
 COPY . /project
 
 WORKDIR /project/user-app
+
+# Maven install
+ARG MAVEN_VERSION=3.6.1
+ARG USER_HOME_DIR="/root"
+ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN mvn install -DskipTests
 
@@ -14,7 +52,7 @@ RUN cd target && \
     mkdir /config && \
     mv wlp/usr/servers/*/* /config/
 
-FROM open-liberty:kernel-java8-openj9
+FROM openliberty/open-liberty:microProfile3-ubi-min
 
 COPY --chown=1001:0 --from=0 /config/ /config/
 


### PR DESCRIPTION
This PR updates the java-microprofile stack to use Redhat UBI base images.