### PR TITLE
Ensure express server starts on production image

### DIFF
--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -23,6 +23,9 @@ WORKDIR /project/user-app
 COPY ./user-app/package*.json ./
 RUN npm install --production
 
+COPY . /project
+RUN chown -hR node:node /project
+
 WORKDIR /project
 
 ENV NODE_ENV production


### PR DESCRIPTION
This PR addresses an issue where the nodejs express server would fail to start on the production container image.

I have added the missing copy and permission changes.

The production image now starts successfully when invoked directly.