### PR TITLE
Update java-microprofile stack for Redhat ceritification requirements

### DIFF
--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,10 +1,20 @@
 FROM registry.access.redhat.com/ubi7/ubi
 
+LABEL vendor="Kabanero" \
+    name="Kabanero java-microprofile" \
+    version="0.1.0" \
+    summary="Image for Kabanero java-microprofile development" \
+    description="This image contains the Kabanero development stack for the java-microprofile collection"
+
 RUN yum upgrade --disableplugin=subscription-manager -y \
    && yum clean --disableplugin=subscription-manager packages \
    && echo 'Finished installing dependencies'
 
 USER root
+
+RUN groupadd --gid 1000 java_group \
+ && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
+
 RUN yum install --disableplugin=subscription-manager -y curl
 
 COPY ./project /project
@@ -27,29 +37,33 @@ RUN set -eux; \
    PATH="/opt/java/openjdk/bin:$PATH"
    ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
-# Maven install
-ARG MAVEN_VERSION=3.6.1
-ARG USER_HOME_DIR="/root"
-ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ # Maven install
+ ARG MAVEN_VERSION=3.6.1
+ ARG USER_HOME_DIR="/root"
+ ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
+ ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+   && rm -f /tmp/apache-maven.tar.gz \
+   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+   ENV MAVEN_HOME /usr/share/maven
+   ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 WORKDIR /project/
-
 RUN mkdir -p /mvn/repository
 RUN mvn -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 RUN mvn -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
 
 WORKDIR /project/user-app
+RUN chown -R java_user:java_group /project
+RUN chown -R java_user:java_group /config
+
+USER java_user
+ENV MAVEN_CONFIG "~/.m2"
 
 ENV APPSODY_MOUNTS="~/.m2/repository:/mvn/repository;src:/project/user-app/src;pom.xml:/project/user-app/pom.xml"
 ENV APPSODY_DEPS=

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,8 +1,8 @@
 FROM registry.access.redhat.com/ubi7/ubi
 
 LABEL vendor="Kabanero" \
-    name="Kabanero java-microprofile" \
-    version="0.1.0" \
+    name="kabanero/java-microprofile" \
+    version="0.2.10" \
     summary="Image for Kabanero java-microprofile development" \
     description="This image contains the Kabanero development stack for the java-microprofile collection"
 

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,10 +1,20 @@
 FROM registry.access.redhat.com/ubi7/ubi
 
+LABEL vendor="Kabanero" \
+    name="Kabanero java-microprofile" \
+    version="0.1.0" \
+    summary="Image for Kabanero java-microprofile development" \
+    description="This image contains the Kabanero development stack for the java-microprofile collection"
+
 RUN yum upgrade --disableplugin=subscription-manager -y \
    && yum clean --disableplugin=subscription-manager packages \
    && echo 'Finished installing dependencies'
 
 USER root
+
+RUN groupadd --gid 1000 java_group \
+ && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
+
 RUN yum install --disableplugin=subscription-manager -y curl
 
 COPY ./LICENSE /licenses/
@@ -28,29 +38,33 @@ RUN set -eux; \
    PATH="/opt/java/openjdk/bin:$PATH"
    ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
-# Maven install
-ARG MAVEN_VERSION=3.6.1
-ARG USER_HOME_DIR="/root"
-ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ # Maven install
+ ARG MAVEN_VERSION=3.6.1
+ ARG USER_HOME_DIR="/root"
+ ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
+ ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+   && rm -f /tmp/apache-maven.tar.gz \
+   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+   ENV MAVEN_HOME /usr/share/maven
+   ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 WORKDIR /project/
-
 RUN mkdir -p /mvn/repository
 RUN mvn -Dmaven.repo.local=/mvn/repository -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 RUN mvn -Dmaven.repo.local=/mvn/repository install dependency:go-offline -DskipTests
 
 WORKDIR /project/user-app
+RUN chown -R java_user:java_group /project
+RUN chown -R java_user:java_group /config
+
+USER java_user
+ENV MAVEN_CONFIG "~/.m2"
 
 ENV APPSODY_MOUNTS="~/.m2/repository:/mvn/repository;src:/project/user-app/src;pom.xml:/project/user-app/pom.xml"
 ENV APPSODY_DEPS=


### PR DESCRIPTION
This PR updates the `Dockerfile-stack` for java-microprofile to enable the docker image to pass Redhat certification.

I have tested the new image with appsody init / run / build and it functions as expected.