### PR TITLE
fix express collection failing on appsody run

### DIFF
--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -38,10 +38,7 @@ COPY ./config /config
 RUN chown -R default:root /project
 WORKDIR /project
 USER default
-RUN mkdir ~/.node \
-  && npm config set prefix ~/.node \
-ENV PATH="$HOME/.node/bin:$PATH"
-ENV NODE_PATH="$HOME/.node/lib/node_modules:$NODE_PATH"
+RUN mkdir -p /project/user-app/node_modules
 RUN npm install
 
 ENV PORT=3000


### PR DESCRIPTION
Following the certification updates the nodejs-express collection would fail when using `appsody run`. The issue was due to permissions given to the volume mount for the node modules.

To resolve the issue we need to create the mount point in the docker file with the correct permissions.

`appsody run` now functions as expected