### PR TITLE
Update Dockerfile to allow correct mount permissions

### DIFF
--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -38,10 +38,7 @@ COPY ./config /config
 RUN chown -R default:root /project
 WORKDIR /project
 USER default
-RUN mkdir ~/.node \
-  && npm config set prefix ~/.node \
-ENV PATH="$HOME/.node/bin:$PATH"
-ENV NODE_PATH="$HOME/.node/lib/node_modules:$NODE_PATH"
+RUN mkdir -p /project/user-app/node_modules
 RUN npm install
 
 WORKDIR /project/user-app


### PR DESCRIPTION
This PR updates the Dockerfile-stack for the nodejs collection to allow the dependancies volume to be mounted with the correct access permissions.

I have been able to appsody init / run / build succesfully following the change.