### PR TITLE
Tekton pipeline to build and host collections in nginx

### DIFF
--- a/ci/ext/post_package.d/kabanero_post_pkg.sh
+++ b/ci/ext/post_package.d/kabanero_post_pkg.sh
@@ -28,3 +28,7 @@ index_src=$base_dir/ci/build/index-src
 if [ -f $index_src/incubator-index.yaml ]; then
     mv $index_src/incubator-index.yaml $index_src/kabanero-index.yaml
 fi
+
+NGINX_IMAGE=nginx-ubi
+image_build -t $NGINX_IMAGE \
+ -f $script_dir/nginx-ubi/Dockerfile $script_dir

--- a/ci/nginx-ubi/Dockerfile
+++ b/ci/nginx-ubi/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+LABEL name="kabanero-index" \
+      vendor="Kabanero" \
+      version="1" \
+      release="1" \
+      summary="Nginx container to host Kabanero collections" \
+      description="Nginx container to host Kabanero collections"
+
+COPY nginx-ubi/nginx.repo  /etc/yum.repos.d/nginx.repo
+
+RUN microdnf install nginx findutils \
+    && mkdir /var/cache/nginx \
+    && chown -R nginx:0 /var/log/nginx/ /var/cache/nginx /usr/share/nginx \
+    && chmod -R g=u /var/log/nginx/ /var/cache/nginx /usr/share/nginx \
+    && mkdir /licenses \
+    && cp /usr/share/doc/nginx*/* /licenses

--- a/ci/nginx-ubi/nginx.repo
+++ b/ci/nginx-ubi/nginx.repo
@@ -1,0 +1,5 @@
+[nginx]
+name=nginx repo
+baseurl=http://nginx.org/packages/rhel/7/$basearch/
+gpgcheck=0
+enabled=1

--- a/ci/tekton/README.md
+++ b/ci/tekton/README.md
@@ -1,0 +1,45 @@
+
+1. Deploy pipeline
+    ```
+    oc apply -f tekton/collections-build-task.yaml -n kabanero
+    ```
+
+1. Configure security constraints for service account
+    ```
+    oc adm policy add-scc-to-user privileged -z kabanero-index -n kabanero
+    ```
+
+1. Create `tekton/collections-build-task-run.yaml` pipeline run file with the following contents. Fill in the `revision`, `url`, and `clusterSubdomain` properties:
+    ```
+    apiVersion: tekton.dev/v1alpha1
+    kind: TaskRun
+    metadata:
+      name: collections-build-task-run
+    spec:
+      serviceAccount: kabanero-index
+      taskRef:
+        name: collections-build-task
+      inputs:
+        resources:
+          - name: git-source
+            resourceSpec:
+              type: git
+              params:
+                - name: revision
+                  value: master
+                - name: url
+                  value: https://github.com/kabanero/collections.git
+        params:
+          - name: clusterSubdomain
+            value: example.com
+    ```
+
+1. If you are using GitHub Enterprise, create a secret following https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-git instructions and associate it with the `kabanero-index` service account. For example:
+    ```
+    oc secrets link kabanero-index basic-user-pass
+    ```
+
+1. Trigger build
+    ```
+    oc delete --ignore-not-found -f tekton/collections-build-task-run.yaml; sleep 5; oc apply -f tekton/collections-build-task-run.yaml
+    ```

--- a/ci/tekton/collections-build-task.yaml
+++ b/ci/tekton/collections-build-task.yaml
@@ -1,0 +1,197 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: collections-build-task
+spec:
+  inputs:
+    resources:
+      - name: git-source
+        type: git
+    params:
+      - name: registry
+        type: string
+        description: Docker registry
+        default: docker-registry.default.svc:5000
+      - name: namespace
+        type: string
+        description: Namespace
+        default: kabanero
+      - name: hostname
+        type: string
+        description: Hostname of the application hosting collections
+        default: kabanero-index
+      - name: clusterSubdomain
+        type: string
+        description: Cluster subdomain
+
+  steps:
+    - name: build-collections
+      securityContext:
+        privileged: true
+      image: quay.io/buildah/stable:v1.9.0
+      command: ["/bin/bash"]
+      args:
+        - -cex
+        - |
+          # install yq
+          curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64
+          chmod +x /usr/local/bin/yq
+
+          # install git
+          yum install -y git which findutils
+
+          # install pyyaml
+          curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+          python3 get-pip.py
+          pip install pyyaml
+
+          # do build and release
+          export USE_BUILDAH="true"
+          export IMAGE_REGISTRY="${inputs.params.registry}"
+          export IMAGE_REGISTRY_ORG="${inputs.params.namespace}"
+          cd /workspace/git-source/
+          ./ci/prefetch.sh
+          ./ci/build.sh .
+          ./ci/release.sh
+      env:
+        - name: gitsource
+          value: git-source
+      volumeMounts:
+        - name: var-lib-containers
+          mountPath: /var/lib/containers
+
+    - name: deploy-collections-index
+      image: lachlanevenson/k8s-kubectl
+      command: ['/bin/sh']
+      args:
+        - -cex
+        - |
+          YAML_FILE=/workspace/git-source/ci/tekton/openshift.yaml
+          sed -i -e 's/HOST/${inputs.params.hostname}.${inputs.params.clusterSubdomain}/' $YAML_FILE
+          sed -i -e 's/REGISTRY/${inputs.params.registry}/' $YAML_FILE
+          sed -i -e 's/NAMESPACE/${inputs.params.namespace}/' $YAML_FILE
+          sed -i -e 's/TAG/latest/' $YAML_FILE
+          sed -i -e "s/DATE/$(date --utc '+%FT%TZ')/" $YAML_FILE
+          kubectl apply --validate=false -f $YAML_FILE
+
+  volumes:
+    - name: var-lib-containers
+      emptyDir: {}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kabanero-index
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kabanero-index
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - deployments
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  attributeRestrictions: null
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  attributeRestrictions: null
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - route.openshift.io
+  attributeRestrictions: null
+  resources:
+  - routes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  attributeRestrictions: null
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  - image.openshift.io
+  attributeRestrictions: null
+  resources:
+  - imagestreams
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  - build.openshift.io
+  attributeRestrictions: null
+  resources:
+  - builds/details
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  - build.openshift.io
+  attributeRestrictions: null
+  resources:
+  - builds
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kabanero-index
+subjects:
+- kind: ServiceAccount
+  name: kabanero-index
+roleRef:
+  kind: Role
+  name: kabanero-index
+  apiGroup: rbac.authorization.k8s.io

--- a/ci/tekton/openshift.yaml
+++ b/ci/tekton/openshift.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kabanero-index
+  labels:
+    app: kabanero-index
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kabanero-index
+  template:
+    metadata:
+      labels:
+        app: kabanero-index
+      annotations:
+        date: "DATE"
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: nginx
+        image: REGISTRY/NAMESPACE/kabanero-index:TAG
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: EXTERNAL_URL
+          value: "http://HOST"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kabanero-index
+  labels:
+    app: kabanero-index
+spec:
+  type: ClusterIP
+  selector:
+    app: kabanero-index
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kabanero-index
+spec:
+  host: HOST
+  to:
+    kind: Service
+    name: kabanero-index


### PR DESCRIPTION
Replaces https://github.com/kabanero-io/collections/pull/35. 

* Add Tekton pipeline for building the collections and hosting the index in nginx container
* Publish the stack Docker images into internal OpenShift registry
* Build and use nginx ubi-based image

### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
* https://github.com/kabanero-io/kabanero-collection/issues/60