### PR TITLE
Remove hardcoded Maven dependency

### DIFF
--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi7/ubi
 
+RUN cat /etc/os-release
+
 LABEL vendor="Kabanero" \
     name="kabanero/java-microprofile" \
     version="0.2.10" \
@@ -15,7 +17,7 @@ USER root
 RUN groupadd --gid 1000 java_group \
  && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
 
-RUN yum install --disableplugin=subscription-manager -y curl
+RUN yum install --disableplugin=subscription-manager -y curl wget
 
 COPY ./LICENSE /licenses/
 COPY ./project /project
@@ -39,20 +41,11 @@ RUN set -eux; \
    ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
  # Maven install
- ARG MAVEN_VERSION=3.6.1
- ARG USER_HOME_DIR="/root"
- ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
- ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo \
+  && yum install --disableplugin=subscription-manager -y maven
 
- RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-   && rm -f /tmp/apache-maven.tar.gz \
-   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-
-   ENV MAVEN_HOME /usr/share/maven
-   ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+  ENV MAVEN_HOME /usr/share/maven
+  ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 WORKDIR /project/
 RUN mkdir -p /mvn/repository

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/ubi7/ubi
 
-RUN cat /etc/os-release
-
 LABEL vendor="Kabanero" \
     name="kabanero/java-microprofile" \
     version="0.2.10" \

--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -6,7 +6,7 @@ RUN yum upgrade --disableplugin=subscription-manager -y \
    && echo 'Finished installing dependencies'
 
 USER root
-RUN yum install --disableplugin=subscription-manager -y unzip curl ca-certificates
+RUN yum install --disableplugin=subscription-manager -y unzip curl ca-certificates wget
 
 #Install openjdk
 ENV JAVA_VERSION jdk8u222-b10_openj9-0.15.1
@@ -30,17 +30,8 @@ COPY . /project
 WORKDIR /project/user-app
 
 # Maven install
-ARG MAVEN_VERSION=3.6.1
-ARG USER_HOME_DIR="/root"
-ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo \
+  && yum install --disableplugin=subscription-manager -y maven
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"

--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -46,17 +46,7 @@ ENV JAVA_HOME=/opt/ibm/java/jre \
 IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
 
 # Maven install
-ARG MAVEN_VERSION=3.6.1
-ARG USER_HOME_DIR="/root"
-ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+RUN yum install --disableplugin=subscription-manager -y maven
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
@@ -68,7 +58,7 @@ COPY ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
 COPY ./mvn-stack-settings.xml /project/mvn-stack-settings.xml
 
 WORKDIR /project
-RUN mvn --no-transfer-progress -B -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
+RUN mvn -B -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 
 WORKDIR /project/user-app
 RUN chown -R java_user:java_group /project

--- a/incubator/java-spring-boot2/image/project/Dockerfile
+++ b/incubator/java-spring-boot2/image/project/Dockerfile
@@ -36,17 +36,7 @@ PATH=/opt/ibm/java/bin:$PATH \
 IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
 
 # Maven install
-ARG MAVEN_VERSION=3.6.1
-ARG USER_HOME_DIR="/root"
-ARG SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-
-RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven.tar.gz \
-  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+RUN yum install --disableplugin=subscription-manager -y maven
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -32,7 +32,7 @@ error() {
 
 run_mvn () {
   echo -e "${GREEN}> mvn $@${NO_COLOR}"
-  mvn --no-transfer-progress "$@"
+  mvn "$@"
 }
 
 version() {
@@ -55,11 +55,11 @@ common() {
     error "Could not find Maven pom.xml
 
     * The project directory (containing an .appsody-conf.yaml file) must contain a pom.xml file.
-    * On Windows and MacOS, the project directory should also be shared with Docker: 
+    * On Windows and MacOS, the project directory should also be shared with Docker:
       - Win: https://docs.docker.com/docker-for-windows/#shared-drives
       - Mac: https://docs.docker.com/docker-for-mac/#file-sharing
     "
-    exit 1   
+    exit 1
   fi
   # workaround: exit with error if repository does not exist
   if [ ! -d /mvn/repository ]; then


### PR DESCRIPTION
This PR updates the java-microprofile and java-spring-boot2 collections to install Maven from a yum repository and therefore removes the hard coded version dependency on Maven.

I have confirmed I can init, build and deploy an application for the collections following the changes.