### PR TITLE
Revert back to using UBI 7 image for java-microprofile

### DIFF
--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi7/ubi
 
 LABEL vendor="Kabanero" \
     name="kabanero/java-microprofile" \
@@ -39,7 +39,8 @@ RUN set -eux; \
    ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
  # Maven install
- RUN yum install --disableplugin=subscription-manager -y maven
+ RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo \
+  && yum install --disableplugin=subscription-manager -y apache-maven
 
   ENV MAVEN_HOME /usr/share/maven
   ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"

--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -1,8 +1,7 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi7/ubi
 
 RUN yum upgrade --disableplugin=subscription-manager -y \
    && yum clean --disableplugin=subscription-manager packages \
-   && mkdir -p /mvn/repository \
    && echo 'Finished installing dependencies'
 
 USER root
@@ -30,7 +29,10 @@ COPY . /project
 WORKDIR /project/user-app
 
 # Maven install
-RUN yum install --disableplugin=subscription-manager -y maven
+RUN mkdir -p /mvn/repository
+
+RUN wget http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo -O /etc/yum.repos.d/epel-apache-maven.repo \
+  && yum install --disableplugin=subscription-manager -y apache-maven
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->