### PR TITLE
Install Maven from tar to avoid compilation errors

### DIFF
--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -46,10 +46,20 @@ ENV JAVA_HOME=/opt/ibm/java/jre \
 IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
 
 # Maven install
-RUN yum install --disableplugin=subscription-manager -y maven
+   ARG MAVEN_VERSION=3.6.2
+   ARG USER_HOME_DIR="/root"
+   ARG SHA=d941423d115cd021514bfd06c453658b1b3e39e6240969caf4315ab7119a77299713f14b620fb2571a264f8dff2473d8af3cb47b05acf0036fc2553199a5c1ee
+   ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
 
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+   && rm -f /tmp/apache-maven.tar.gz \
+   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ ENV MAVEN_HOME /usr/share/maven
+ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 COPY ./LICENSE /licenses/
 
@@ -65,8 +75,10 @@ WORKDIR /project
 RUN mvn -B -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
 
 WORKDIR /project/user-app
+RUN mkdir -p /mvn/repository
 RUN chown -R java_user:java_group /project
 RUN chown -R java_user:java_group /config
+RUN chown -R java_user:java_group /mvn
 
 USER java_user
 ENV MAVEN_CONFIG "~/.m2"

--- a/incubator/java-spring-boot2/image/project/Dockerfile
+++ b/incubator/java-spring-boot2/image/project/Dockerfile
@@ -36,7 +36,17 @@ PATH=/opt/ibm/java/bin:$PATH \
 IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
 
 # Maven install
-RUN yum install --disableplugin=subscription-manager -y maven
+ARG MAVEN_VERSION=3.6.2
+ARG USER_HOME_DIR="/root"
+ARG SHA=d941423d115cd021514bfd06c453658b1b3e39e6240969caf4315ab7119a77299713f14b620fb2571a264f8dff2473d8af3cb47b05acf0036fc2553199a5c1ee
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+ && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+ && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+ && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+ && rm -f /tmp/apache-maven.tar.gz \
+ && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"


### PR DESCRIPTION
This PR updates the java-spring-boot2 collection to install Maven via a tar ball.

This change is to avoid similar compilation problems seen while using the package managers maven version under java-microprofile.

I have tested appsody init / build / run successfully.