### PR TITLE
aadeshpa issue 40 updated the substitution variable

### DIFF
--- a/incubator/common/pipelines/default/build-deploy-pipeline.yaml
+++ b/incubator/common/pipelines/default/build-deploy-pipeline.yaml
@@ -1,8 +1,8 @@
-#Kabanero! on activate substitute CollectionName for text '${collection-name}'
+#Kabanero! on activate substitute CollectionId for text 'CollectionId'
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
 metadata:
-  name: ${collection-name}-build-deploy-pipeline
+  name: CollectionId-build-deploy-pipeline
 spec:
   resources:
     - name: git-source
@@ -12,7 +12,7 @@ spec:
   tasks:
     - name: build-task
       taskRef:
-        name: ${collection-name}-build-task
+        name: CollectionId-build-task
       resources:
         inputs:
         - name: git-source
@@ -22,7 +22,7 @@ spec:
           resource: docker-image
     - name: deploy-task
       taskRef:
-        name: ${collection-name}-deploy-task
+        name: CollectionId-deploy-task
       runAfter: [build-task]
       resources:
         inputs:

--- a/incubator/common/pipelines/default/build-task.yaml
+++ b/incubator/common/pipelines/default/build-task.yaml
@@ -1,8 +1,8 @@
-#Kabanero! on activate substitute CollectionName for text '${collection-name}'
+#Kabanero! on activate substitute CollectionId for text 'CollectionId'
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
-  name: ${collection-name}-build-task
+  name: CollectionId-build-task
 spec:
   inputs:
     resources:

--- a/incubator/common/pipelines/default/deploy-task.yaml
+++ b/incubator/common/pipelines/default/deploy-task.yaml
@@ -1,8 +1,8 @@
-#Kabanero! on activate substitute CollectionName for text '${collection-name}'
+#Kabanero! on activate substitute CollectionId for text 'CollectionId'
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
-  name: ${collection-name}-deploy-task
+  name: CollectionId-deploy-task
 spec:
   inputs:
     resources:
@@ -12,7 +12,7 @@ spec:
         type: image
     params:
       - name: repository-name
-        default: ${collection-name}
+        default: CollectionId
       - name: app-deploy-file-name
         default: app-deploy.yaml
   steps:


### PR DESCRIPTION
After discussion with Kyle with his fix for the substituon of the collection name, we chnaged the ${collection-name} to 'CollectionId' in all pipeline and task files.
Reference PR of kyle : https://github.com/kabanero-io/kabanero-operator/pull/161

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

- [ ] Stack adheres to [Appsody stack structure](https://github.com/appsody/website/blob/master/content/docs/stacks/stack-structure.md).


### Modifying an existing stack:

- [ ] Updated the stack version in `stack.yaml`

<!--- Describe your changes in detail -->

### Contributing a new stack:

- Describe how application dependencies are managed:

- Explain how Appsody file watcher is utilized:

- Describe other Appsody environment variables defined by the stack image:

- Describe any limitations and known issues:


### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->