### PR TITLE
Update to allow stack name to use IMAGE_REGISTRY_ORG

### DIFF
--- a/ci/ext/add_collection_resources.sh
+++ b/ci/ext/add_collection_resources.sh
@@ -110,7 +110,7 @@ then
     yq m -x -i $index_file $collection
 
     # find the name of the default image in the collection.yaml
-    default_imageId=$(yq r $index_file default-image) 
+    default_imageId=$(yq r $index_file default-image)
     imagesCount=$(yq r $index_file images | awk '$1 == "-" { count++ } END { print count }')
     count=0
     while [ $count -lt $imagesCount ]
@@ -119,6 +119,7 @@ then
         if [ $default_imageId == $imageId ]
         then
             default_image=$(yq r $index_file images.[$count].image)
+            default_image="${default_image/\$IMAGE_REGISTRY_ORG/${IMAGE_REGISTRY_ORG}}"
         fi
         count=$(( $count + 1 ))
     done

--- a/incubator/java-microprofile/collection.yaml
+++ b/incubator/java-microprofile/collection.yaml
@@ -2,4 +2,4 @@ default-image: java-microprofile
 default-pipeline: default
 images:
 - id: java-microprofile
-  image: kabanero/java-microprofile:0.2
+  image: $IMAGE_REGISTRY_ORG/java-microprofile:0.2

--- a/incubator/java-spring-boot2/collection.yaml
+++ b/incubator/java-spring-boot2/collection.yaml
@@ -2,4 +2,4 @@ default-image: java-spring-boot2
 default-pipeline: default
 images:
 - id: java-spring-boot2
-  image: kabanero/java-spring-boot2:0.3
+  image: $IMAGE_REGISTRY_ORG/java-spring-boot2:0.3

--- a/incubator/nodejs-express/collection.yaml
+++ b/incubator/nodejs-express/collection.yaml
@@ -2,4 +2,4 @@ default-image: nodejs-express
 default-pipeline: default
 images:
 - id: nodejs-express
-  image: kabanero/nodejs-express:0.2
+  image: $IMAGE_REGISTRY_ORG/nodejs-express:0.2

--- a/incubator/nodejs-loopback/collection.yaml
+++ b/incubator/nodejs-loopback/collection.yaml
@@ -2,4 +2,4 @@ default-image: nodejs-loopback
 default-pipeline: default
 images:
 - id: nodejs-loopback
-  image: kabanero/nodejs-loopback:0.1
+  image: $IMAGE_REGISTRY_ORG/nodejs-loopback:0.1

--- a/incubator/nodejs/collection.yaml
+++ b/incubator/nodejs/collection.yaml
@@ -2,4 +2,4 @@ default-image: nodejs
 default-pipeline: default
 images:
 - id: nodejs
-  image: kabanero/nodejs:0.2
+  image: $IMAGE_REGISTRY_ORG/nodejs:0.2


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

<!--- Describe your changes in detail -->
Update the build script to allow substitution of IMAGE_REGISTRY_ORG env var into the templates.

### Related Issues:
Resolves: https://github.com/kabanero-io/collections/issues/74