### PR TITLE
Set the codewind DISPLAY_NAME_PREFIX to be "Kabanero"

### DIFF
--- a/ci/ext/pre_env.d/kabanero_pre_env.sh
+++ b/ci/ext/pre_env.d/kabanero_pre_env.sh
@@ -17,3 +17,7 @@ fi
 if [ -z $INDEX_IMAGE ]; then
     export INDEX_IMAGE=kabanero-index
 fi 
+if [ -z "$DISPLAY_NAME_PREFIX" ]
+then
+    export DISPLAY_NAME_PREFIX="Kabanero"
+fi


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
<!--- Describe your changes in detail -->
Set the  DISPLAY_NAME_PREFIX environment variable to be "Kabanero" rather than the default of "Appsody", for use in generating the codewind index json file.

### Related Issues:
https://github.com/kabanero-io/collections/issues/81