### PR TITLE
Move executable definitions for sha256cmd

### DIFF
--- a/ci/ext/add_collection_resources.sh
+++ b/ci/ext/add_collection_resources.sh
@@ -92,12 +92,6 @@ process_assets () {
     fi
 }
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sha256cmd="shasum --algorithm 256"    # Mac OSX
-else
-    sha256cmd="sha256sum "  # other OSs
-fi
-
 if [ -f $collection ]
 then
     # check to see if we have maintainers in the collection.yaml

--- a/ci/ext/add_collections.sh
+++ b/ci/ext/add_collections.sh
@@ -17,6 +17,13 @@ mkdir -p $assets_dir
 # url for downloading released assets
 release_url="https://github.com/$TRAVIS_REPO_SLUG/releases/download"
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sha256cmd="shasum --algorithm 256"    # Mac OSX
+else
+    sha256cmd="sha256sum "  # other OSs
+fi
+
+
 build_asset_tar () {
     asset_build=$assets_dir/asset_temp
     mkdir -p $asset_build


### PR DESCRIPTION
Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Moved executable definitions for sha256cmd into correct script file following previous refactoring.

### Related Issues:
Fixes https://github.com/kabanero-io/collections/issues/86