### PR TITLE
Use OpenJDK for spring-boot2 collection

### DIFF
--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -21,29 +21,20 @@ RUN yum install --disableplugin=subscription-manager -y https://dl.fedoraproject
 
 # java8 install
 RUN yum install --disableplugin=subscription-manager -y wget ca-certificates
-ENV JAVA_VERSION 1.8.0_sr5fp37
 
 RUN set -eux; \
-    ESUM='51f6600dcc51c238bd4fbed73521e225094d7afa9afa2c8fb35ea78519a71930'; \
-    YML_FILE='sdk/linux/x86_64/index.yml'; \
-    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
-    wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
-    JAVA_URL=$(sed -n '/^'${JAVA_VERSION}:'/{n;s/\s*uri:\s//p}'< /tmp/index.yml); \
-    wget -q -U UA_IBM_JAVA_Docker -O /tmp/ibm-java.bin ${JAVA_URL}; \
-    echo "${ESUM}  /tmp/ibm-java.bin" | sha256sum -c -; \
-    echo "INSTALLER_UI=silent" > /tmp/response.properties; \
-    echo "USER_INSTALL_DIR=/opt/ibm/java" >> /tmp/response.properties; \
-    echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties; \
-    mkdir -p /opt/ibm; \
-    chmod +x /tmp/ibm-java.bin; \
-    /tmp/ibm-java.bin -i silent -f /tmp/response.properties; \
-    rm -f /tmp/response.properties; \
-    rm -f /tmp/index.yml; \
-    rm -f /tmp/ibm-java.bin;
+ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
+BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
+curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+mkdir -p /opt/java/openjdk; \
+cd /opt/java/openjdk; \
+tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+rm -rf /tmp/openjdk.tar.gz;
 
-ENV JAVA_HOME=/opt/ibm/java/jre \
-    PATH=/opt/ibm/java/bin:$PATH \
-IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
+ENV JAVA_HOME=/opt/java/openjdk \
+PATH="/opt/java/openjdk/bin:$PATH"
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
 # Maven install
    ARG MAVEN_VERSION=3.6.2

--- a/incubator/java-spring-boot2/image/project/Dockerfile
+++ b/incubator/java-spring-boot2/image/project/Dockerfile
@@ -11,29 +11,20 @@ RUN yum install --disableplugin=subscription-manager -y https://dl.fedoraproject
 
 # java8 install
 RUN yum install --disableplugin=subscription-manager -y wget ca-certificates
-ENV JAVA_VERSION 1.8.0_sr5fp37
 
 RUN set -eux; \
-   ESUM='51f6600dcc51c238bd4fbed73521e225094d7afa9afa2c8fb35ea78519a71930'; \
-   YML_FILE='sdk/linux/x86_64/index.yml'; \
-   BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
-   wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
-   JAVA_URL=$(sed -n '/^'${JAVA_VERSION}:'/{n;s/\s*uri:\s//p}'< /tmp/index.yml); \
-   wget -q -U UA_IBM_JAVA_Docker -O /tmp/ibm-java.bin ${JAVA_URL}; \
-   echo "${ESUM}  /tmp/ibm-java.bin" | sha256sum -c -; \
-   echo "INSTALLER_UI=silent" > /tmp/response.properties; \
-   echo "USER_INSTALL_DIR=/opt/ibm/java" >> /tmp/response.properties; \
-   echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties; \
-   mkdir -p /opt/ibm; \
-   chmod +x /tmp/ibm-java.bin; \
-   /tmp/ibm-java.bin -i silent -f /tmp/response.properties; \
-   rm -f /tmp/response.properties; \
-   rm -f /tmp/index.yml; \
-   rm -f /tmp/ibm-java.bin;
+  ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
+  BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
+  curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+  echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+  mkdir -p /opt/java/openjdk; \
+  cd /opt/java/openjdk; \
+  tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+  rm -rf /tmp/openjdk.tar.gz;
 
-ENV JAVA_HOME=/opt/ibm/java/jre \
-PATH=/opt/ibm/java/bin:$PATH \
-IBM_JAVA_OPTIONS="-XX:+UseContainerSupport"
+  ENV JAVA_HOME=/opt/java/openjdk \
+  PATH="/opt/java/openjdk/bin:$PATH"
+  ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
 # Maven install
 ARG MAVEN_VERSION=3.6.2


### PR DESCRIPTION
This PR updates the java-spring-boot2 collection to use OpenJDK.

This will resolve the issue of the IBM JDK download being removed and allow appsody build / deploy to complete.