### PR TITLE
Fix steps to clone collections locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Click here to find out more about the [Repository structure](https://github.com/
 1. Clone the collections repository and create a new copy of it in your git organization:
    ```bash
    git clone https://github.com/kabanero-io/collections.git
+   cd collections
    git remote add private-org https://github.acme.com/my_org/collections.git
    git push -u private-org
-   cd collections
    ```
    Once this has been done, you will have your own copy of the collections repository in your own git org/repo. Follow any normal development processes you have for using git (i.e., creating branches, etc.).
 


### PR DESCRIPTION
The user has to `cd collections` before `git` will recognize the collections repository to add a remote, or push.

### Checklist:

- [ ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Just a doc update

### Related Issues:
No related issue.