### PR TITLE
Build base docker images to improve stability

### DIFF
--- a/docker/Dockerfile-maven
+++ b/docker/Dockerfile-maven
@@ -1,0 +1,27 @@
+FROM kabanero/ubi8-openjdk
+
+RUN yum upgrade --disableplugin=subscription-manager -y \
+   && yum clean --disableplugin=subscription-manager packages \
+   && echo 'Finished installing dependencies'
+
+USER root
+
+# Dependency install
+RUN yum install --disableplugin=subscription-manager -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+   && yum install --disableplugin=subscription-manager -y unzip curl ca-certificates wget xmlstarlet
+
+# Maven install
+ARG MAVEN_VERSION=3.6.2
+ARG USER_HOME_DIR="/root"
+ARG SHA=d941423d115cd021514bfd06c453658b1b3e39e6240969caf4315ab7119a77299713f14b620fb2571a264f8dff2473d8af3cb47b05acf0036fc2553199a5c1ee
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"

--- a/docker/Dockerfile-ubi8-openJDK
+++ b/docker/Dockerfile-ubi8-openJDK
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+RUN yum upgrade --disableplugin=subscription-manager -y \
+   && yum clean --disableplugin=subscription-manager packages \
+   && echo 'Finished installing dependencies'
+
+USER root
+
+#Install openjdk
+ENV JAVA_VERSION jdk8u222-b10_openj9-0.15.1
+
+RUN set -eux; \
+   ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
+   BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
+   curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+   mkdir -p /opt/java/openjdk; \
+   cd /opt/java/openjdk; \
+   tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+   rm -rf /tmp/openjdk.tar.gz;
+
+   ENV JAVA_HOME=/opt/java/openjdk \
+   PATH="/opt/java/openjdk/bin:$PATH"
+   ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"

--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker build -t kabanero/ubi8-openjdk -f ./Dockerfile-ubi8-openJDK .
+
+docker build -t kabanero/ubi8-maven -f ./Dockerfile-maven .

--- a/incubator/java-microprofile/image/Dockerfile-stack
+++ b/incubator/java-microprofile/image/Dockerfile-stack
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM kabanero/ubi8-maven
 
 LABEL vendor="Kabanero" \
     name="kabanero/java-microprofile" \
@@ -6,55 +6,15 @@ LABEL vendor="Kabanero" \
     summary="Image for Kabanero java-microprofile development" \
     description="This image contains the Kabanero development stack for the java-microprofile collection"
 
-RUN yum upgrade --disableplugin=subscription-manager -y \
-   && yum clean --disableplugin=subscription-manager packages \
-   && echo 'Finished installing dependencies'
-
 USER root
 
 RUN groupadd --gid 1000 java_group \
  && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
 # Dependency install
 
-RUN yum install --disableplugin=subscription-manager -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    && yum install --disableplugin=subscription-manager -y curl xmlstarlet wget
-
 COPY ./LICENSE /licenses/
 COPY ./project /project
 COPY ./config /config
-
-#Install openjdk
-ENV JAVA_VERSION jdk8u222-b10_openj9-0.15.1
-
-RUN set -eux; \
-   ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
-   BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
-   curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
-   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
-   mkdir -p /opt/java/openjdk; \
-   cd /opt/java/openjdk; \
-   tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
-   rm -rf /tmp/openjdk.tar.gz;
-
-   ENV JAVA_HOME=/opt/java/openjdk \
-   PATH="/opt/java/openjdk/bin:$PATH"
-   ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
-
-   # Maven install
-   ARG MAVEN_VERSION=3.6.2
-   ARG USER_HOME_DIR="/root"
-   ARG SHA=d941423d115cd021514bfd06c453658b1b3e39e6240969caf4315ab7119a77299713f14b620fb2571a264f8dff2473d8af3cb47b05acf0036fc2553199a5c1ee
-   ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
-
-   RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-    && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-    && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-    && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-    && rm -f /tmp/apache-maven.tar.gz \
-    && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 RUN  /project/util/check_version build
 

--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -1,47 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi
-
-RUN yum upgrade --disableplugin=subscription-manager -y \
-   && yum clean --disableplugin=subscription-manager packages \
-   && echo 'Finished installing dependencies'
+FROM kabanero/ubi8-maven
 
 USER root
-
-# Dependency install
-RUN yum install --disableplugin=subscription-manager -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-   && yum install --disableplugin=subscription-manager -y unzip curl ca-certificates wget xmlstarlet
-
-#Install openjdk
-ENV JAVA_VERSION jdk8u222-b10_openj9-0.15.1
-
-RUN set -eux; \
-   ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
-   BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
-   curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
-   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
-   mkdir -p /opt/java/openjdk; \
-   cd /opt/java/openjdk; \
-   tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
-   rm -rf /tmp/openjdk.tar.gz;
-
-   ENV JAVA_HOME=/opt/java/openjdk \
-   PATH="/opt/java/openjdk/bin:$PATH"
-   ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
-
-# Maven install
-ARG MAVEN_VERSION=3.6.2
-ARG USER_HOME_DIR="/root"
-ARG SHA=d941423d115cd021514bfd06c453658b1b3e39e6240969caf4315ab7119a77299713f14b620fb2571a264f8dff2473d8af3cb47b05acf0036fc2553199a5c1ee
-ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
-
- RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-   && rm -f /tmp/apache-maven.tar.gz \
-   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 COPY . /project
 

--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM kabanero/ubi8-maven
 
 # passed in via package script
 ARG GIT_ORG_REPO=appsody/stacks
@@ -18,49 +18,6 @@ USER root
 
 RUN groupadd --gid 1000 java_group \
   && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
-
-RUN yum upgrade --disableplugin=subscription-manager -y \
-   && yum clean --disableplugin=subscription-manager packages \
-   && echo 'Finished installing dependencies'
-
-# Dependency install
-RUN yum install --disableplugin=subscription-manager -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-   && yum install --disableplugin=subscription-manager -y curl unzip xmlstarlet
-
-# java8 install
-RUN yum install --disableplugin=subscription-manager -y wget ca-certificates
-ENV JAVA_VERSION 1.8.0_sr5fp37
-
-RUN set -eux; \
-   ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
-   BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
-   curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
-   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
-   mkdir -p /opt/java/openjdk; \
-   cd /opt/java/openjdk; \
-   tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
-   rm -rf /tmp/openjdk.tar.gz;
-
-   ENV JAVA_HOME=/opt/java/openjdk \
-   PATH="/opt/java/openjdk/bin:$PATH"
-   ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
-
-# Maven install
-   ARG MAVEN_VERSION=3.6.2
-   ARG USER_HOME_DIR="/root"
-   ARG SHA=d941423d115cd021514bfd06c453658b1b3e39e6240969caf4315ab7119a77299713f14b620fb2571a264f8dff2473d8af3cb47b05acf0036fc2553199a5c1ee
-   ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/
-
- RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
-   && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
-   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
-   && rm -f /tmp/apache-maven.tar.gz \
-   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
-
-
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 
 COPY ./LICENSE /licenses/
 

--- a/incubator/java-spring-boot2/image/project/Dockerfile
+++ b/incubator/java-spring-boot2/image/project/Dockerfile
@@ -13,7 +13,7 @@ RUN /project/util/check_version build \
 USER java_user
 
 ####
-FROM registry.access.redhat.com/ubi8/ubi
+FROM kabanero/ubi8-openjdk
 
 ARG artifactId=appsody-spring
 ARG version=1.0-SNAPSHOT
@@ -23,29 +23,6 @@ LABEL maintainer="IBM Java Engineering at IBM Cloud"
 LABEL org.opencontainers.image.version=${version}
 LABEL org.opencontainers.image.title=${artifactId}
 LABEL appsody.stack="kabanero/java-spring-boot2:0.3.13"
-
-#Install openj9 v8
-
-RUN yum upgrade --disableplugin=subscription-manager -y \
-   && yum clean --disableplugin=subscription-manager packages
-
-RUN yum install --disableplugin=subscription-manager -y curl ca-certificates
-
-ENV JAVA_VERSION jdk8u222-b10_openj9-0.15.1
-
-RUN set -eux; \
-   ESUM='20cff719c6de43f8bb58c7f59e251da7c1fa2207897c9a4768c8c669716dc819'; \
-   BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz'; \
-   curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
-   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
-   mkdir -p /opt/java/openjdk; \
-   cd /opt/java/openjdk; \
-   tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
-   rm -rf /tmp/openjdk.tar.gz;
-
-   ENV JAVA_HOME=/opt/java/openjdk \
-   PATH="/opt/java/openjdk/bin:$PATH"
-   ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions -XX:+UseContainerSupport -XX:+IdleTuningCompactOnIdle -XX:+IdleTuningGcOnIdle"
 
 COPY --from=compile /project/user-app/target/app.jar /app.jar
 


### PR DESCRIPTION
This PR adds new Dockerfiles for building base ubi8 images with openJDK and maven. It also adds a simple script to build the images in the local registry.

The PR also updates the java-spring-boot2 and java-microprofile collections to use these images as a base.

I have successfully built and tested the collections affected.