### PR TITLE
Disable tests in Tekton pipeline

### DIFF
--- a/ci/tekton/README.md
+++ b/ci/tekton/README.md
@@ -41,5 +41,5 @@
 
 1. Trigger build
     ```
-    oc delete --ignore-not-found -f tekton/collections-build-task-run.yaml; sleep 5; oc apply -f tekton/collections-build-task-run.yaml
+    oc delete -n kabanero --ignore-not-found -f tekton/collections-build-task-run.yaml; sleep 5; oc apply -n kabanero -f tekton/collections-build-task-run.yaml
     ```

--- a/ci/tekton/collections-build-task.yaml
+++ b/ci/tekton/collections-build-task.yaml
@@ -51,6 +51,8 @@ spec:
           export IMAGE_REGISTRY="${inputs.params.registry}"
           export IMAGE_REGISTRY_ORG="${inputs.params.namespace}"
           export IMAGE_REGISTRY_PUBLISH="true"
+          # disable tests as 'appsody run' does not work without docker
+          export SKIP_TESTS="true"
           cd /workspace/git-source/
           ./ci/prefetch.sh
           ./ci/build.sh .


### PR DESCRIPTION
Disable tests when running through a Tekton pipeline. Tests execute `appsody run` which requires Docker.

> ### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
<!--- Describe your changes in detail -->

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->