### PR TITLE
First pass at Spring RHR

### DIFF
--- a/incubator/java-spring-boot2-rhr/README.md
+++ b/incubator/java-spring-boot2-rhr/README.md
@@ -1,0 +1,58 @@
+# Spring® Boot 2 Stack
+
+The Spring Boot 2 stack supports the development of [Spring Boot 2](https://spring.io/projects/spring-boot) applications using [Red Hat Runtimes](https://www.redhat.com/en/products/runtimes).
+
+The Spring Boot 2 stack uses a parent Maven project object model (POM) to manage dependency versions and provide required capabilities and plugins. Specifically, this stack enables [Spring Boot Actuator](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-actuator), the Prometheus Micrometer reporter, and OpenTracing support for Spring using a Jaeger tracer.
+
+The [Spring Developer Tools](https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-devtools.html#using-boot-devtools) module is also included to support automatic restarts and live reloading during development.
+
+**Note:** Maven is provided by the Appsody stack container, allowing you to build, test, and debug your Java application without installing Maven locally. We recommend installing Maven locally for the best IDE experience.
+
+## Templates
+
+Templates are used to create your local project and start your development.
+
+The default template provides a `pom.xml` file that references the parent POM defined by the stack, and a simple Spring Boot application main class that defines a basic [liveness endpoint](#health-checks-readiness-and-liveness), and a set of unit tests that ensure enabled actuator endpoints work properly: `/actuator/health`, `/actuator/metrics`, `/actuator/prometheus`, and `actuator/liveness`.
+
+## Getting Started
+
+1. Create a new folder in your local directory and initialize it using the Appsody CLI, e.g.:
+
+    ```bash
+    mkdir my-project
+    cd my-project
+    appsody init java-spring-boot2-rhr
+    ```
+
+    This will initialize a Spring Boot 2 project using the microservice template.
+
+1. Once your project has been initialized you can then run your application using the following command:
+
+    ```bash
+    appsody run
+    ```
+
+    This launches a Docker container that will run your application in the foreground, exposing it on port 8080. The application will be restarted automatically when changes are detected.
+
+1. You should be able to access the following endpoints, as they are exposed by your template application by default:
+
+    - Health endpoint: http://localhost:8080/actuator/health
+    - Liveness endpoint: http://localhost:8080/actuator/liveness
+    - Metrics endpoint: http://localhost:8080/actuator/metrics
+    - Prometheus endpoint: http://localhost:8080/actuator/prometheus
+
+## Health checks, readiness and liveness
+
+Kubernetes defines two integral mechanisms for checking the health of a container:
+
+* A readiness probe is used to indicate whether the process can handle requests (is routable). Kubernetes doesn't route work to a container with a failing readiness probe. A readiness probe should fail if a service hasn't finished initializing, or is otherwise busy, overloaded, or unable to process requests.
+
+* A liveness probe is used to indicate whether the process should be restarted. Kubernetes stops and restarts a container with a failing liveness probe to ensure that Pods in a defunct state are terminated and replaced. A liveness probe should fail if the service is in an irrecoverable state, for example, if an out of memory condition occurs. Simple liveness checks that always return an OK response can identify containers in an inconsistent state, which can happen when process serving requests has crashed but the container is still running.
+
+The Spring Boot 2 Actuator defines an `/actuator/health` endpoint, which returns a {"status": "UP"} payload when all is well. This endpoint is enabled by default, and requires no application code. This actuator works well as a Kubernetes readiness probe, as it automatically includes the status of required resources.
+
+The health endpoint is less useful as a liveness check. In Spring Boot 2, the Actuator framework can be trivially extended with custom endpoints. Your application will include a trivial endpoint to be used as a Kubernetes liveness probe.
+
+## License
+
+This stack is licensed under the [Apache 2.0](./image/LICENSE) license

--- a/incubator/java-spring-boot2-rhr/collection.yaml
+++ b/incubator/java-spring-boot2-rhr/collection.yaml
@@ -1,0 +1,5 @@
+default-image: java-spring-boot2-rhr
+default-pipeline: default
+images:
+- id: java-spring-boot2-rhr
+  image: $IMAGE_REGISTRY_ORG/java-spring-boot2-rhr:0.1

--- a/incubator/java-spring-boot2-rhr/image/.dockerignore
+++ b/incubator/java-spring-boot2-rhr/image/.dockerignore
@@ -1,0 +1,4 @@
+**/target
+**/.git
+**/.gitignore
+**/.vscode

--- a/incubator/java-spring-boot2-rhr/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2-rhr/image/Dockerfile-stack
@@ -1,0 +1,90 @@
+FROM kabanero/ubi8-maven
+
+# passed in via package script
+ARG GIT_ORG_REPO=appsody/stacks
+ARG IMAGE_REGISTRY_ORG=appsody
+ARG STACK_ID=java-spring-boot2-rhr
+ARG MAJOR_VERSION=0
+ARG MINOR_VERSION=1
+ARG PATCH_VERSION=1
+
+LABEL vendor="Kabanero" \
+    name="kabanero/java-spring-boot2-rhr" \
+    version="0.1.1" \
+    summary="Image for Kabanero java-spring-boot2-rhr development" \
+    description="This image contains the Kabanero development stack for the java-spring-boot2-rhr collection"
+
+USER root
+
+RUN groupadd --gid 1000 java_group \
+  && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
+
+COPY ./LICENSE /licenses/
+
+COPY ./project /project
+COPY ./config /config
+COPY ./mvn-stack-settings.xml /usr/share/maven/conf/settings.xml
+COPY ./mvn-stack-settings.xml /project/mvn-stack-settings.xml
+
+
+# Verify properties used to control versions match between this stack and official spring dependencies.
+RUN /project/verify-property-versions.sh
+
+# Build utility for version range processing
+# Install maven wrapper in /project
+RUN mkdir -p /mvn/repository \
+ && /project/util/check_version build \
+ && cd /project \
+ && mvn --no-transfer-progress -B -N io.takari:maven:wrapper -Dmaven=$(mvn help:evaluate -Dexpression=maven.version -q -DforceStdout)
+
+# Update maven artifacts to use stack version information
+# Update Dockerfile to build from this appsody stack image (by range)
+RUN if [ ${MAJOR_VERSION} -eq 0 ]; then \
+      export IMAGE_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}; \
+    else \
+      export IMAGE_VERSION=${MAJOR_VERSION}; \
+    fi \
+ && export MAVEN_ARTIFACT_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}" \
+ && sed -i -e "s|{{APPSODY_STACK}}|${IMAGE_REGISTRY_ORG}/${STACK_ID}:${IMAGE_VERSION}|" \
+           -e "s|{{APPSODY_STACK_FULL}}|${IMAGE_REGISTRY_ORG}/${STACK_ID}:${MAVEN_ARTIFACT_VERSION}|" /project/Dockerfile \
+ && sed -i -e "s|{{MAVEN_ARTIFACT_VERSION}}|${MAVEN_ARTIFACT_VERSION}|" /project/appsody-boot2-pom.xml
+
+WORKDIR /project/user-app
+
+RUN mkdir -p /mvn/repository
+RUN chown -R java_user:java_group /project
+RUN chown -R java_user:java_group /config
+RUN chown -R java_user:java_group /mvn
+
+USER java_user
+ENV MAVEN_CONFIG "~/.m2"
+
+ENV APPSODY_USER_RUN_AS_LOCAL=true
+ENV APPSODY_PROJECT_DIR="/project"
+
+ENV APPSODY_MOUNTS=".:/project/user-app;~/.m2/repository:/mvn/repository"
+ENV APPSODY_DEPS=
+
+ENV APPSODY_WATCH_DIR="/project/user-app/src"
+ENV APPSODY_WATCH_IGNORE_DIR=""
+ENV APPSODY_WATCH_REGEX="(^.*\.java$)|(^.*\.properties$)|(^.*\.yaml$)|(^.*\.html$)|(^.*\.sql$)|(^.*\.js$)|(^.*\.properties$)"
+
+ENV APPSODY_RUN="/project/java-spring-boot2-build.sh run"
+ENV APPSODY_RUN_ON_CHANGE="/project/java-spring-boot2-build.sh recompile"
+ENV APPSODY_RUN_KILL=false
+
+ENV APPSODY_DEBUG="/project/java-spring-boot2-build.sh debug"
+ENV APPSODY_DEBUG_ON_CHANGE="/project/java-spring-boot2-build.sh recompile"
+ENV APPSODY_DEBUG_KILL=false
+
+ENV APPSODY_TEST="/project/java-spring-boot2-build.sh test"
+ENV APPSODY_TEST_ON_CHANGE=""
+ENV APPSODY_TEST_KILL=true
+
+ENV PORT=8080
+
+EXPOSE 8080
+EXPOSE 8443
+EXPOSE 5005
+EXPOSE 35729
+ENTRYPOINT ["/project/java-spring-boot2-build.sh", "run"]

--- a/incubator/java-spring-boot2-rhr/image/LICENSE
+++ b/incubator/java-spring-boot2-rhr/image/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/incubator/java-spring-boot2-rhr/image/config/app-deploy.yaml
+++ b/incubator/java-spring-boot2-rhr/image/config/app-deploy.yaml
@@ -1,0 +1,30 @@
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: APPSODY_PROJECT_NAME
+spec:
+  # Add fields here
+  version: 1.0.0
+  applicationImage: APPSODY_DOCKER_IMAGE 
+  stack: APPSODY_STACK
+  service:
+    type: NodePort
+    port: APPSODY_PORT
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: '/actuator/prometheus'
+  readinessProbe:
+    failureThreshold: 12
+    httpGet:
+      path: /actuator/health
+      port: APPSODY_PORT
+    initialDelaySeconds: 5
+    periodSeconds: 2
+  livenessProbe:
+    failureThreshold: 12
+    httpGet:
+      path: /actuator/liveness
+      port: APPSODY_PORT
+    initialDelaySeconds: 5
+    periodSeconds: 2
+  expose: true

--- a/incubator/java-spring-boot2-rhr/image/mvn-stack-settings.xml
+++ b/incubator/java-spring-boot2-rhr/image/mvn-stack-settings.xml
@@ -1,0 +1,15 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- Use this file to customize maven repositories or other proxies that should be 
+       used when building projects: 
+       Defaults: https://maven.apache.org/settings.html
+       Reference: https://maven.apache.org/ref/3.6.1/maven-settings/settings.html
+  -->
+
+  <!-- Repository location in docker image -->
+  <localRepository>/mvn/repository</localRepository>
+
+</settings>

--- a/incubator/java-spring-boot2-rhr/image/project/.appsody-init.bat
+++ b/incubator/java-spring-boot2-rhr/image/project/.appsody-init.bat
@@ -1,0 +1,10 @@
+if not exist %SystemDrive%%HOMEPATH%\.m2\repository\ (
+  mkdir %SystemDrive%%HOMEPATH%\.m2\repository
+)
+setlocal
+set JAVA_FOUND=0
+where java >nul 2>nul
+if %ERRORLEVEL% EQU 0 set JAVA_FOUND=1
+if defined JAVA_HOME set JAVA_FOUND=1
+if "%JAVA_FOUND%"==1 mvnw install -q -f ./appsody-boot2-pom.xml
+

--- a/incubator/java-spring-boot2-rhr/image/project/.appsody-init.sh
+++ b/incubator/java-spring-boot2-rhr/image/project/.appsody-init.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ] && [ -x /usr/bin/tput ] && [[ `tput colors` != "0" ]]; then
+  color_prompt="yes"
+else
+  color_prompt=
+fi
+
+if [[ "$color_prompt" == "yes" ]]; then
+      BLUE="\033[0;34m"
+  NO_COLOR="\033[0m"
+else
+        BLUE=""
+  NO_COLOUR=""
+fi
+
+if [ ! -d ~/.m2/repository ]; then
+  echo -e "${BLUE}Creating local maven repository:  ~/.m2/repository${NO_COLOR}"
+  mkdir -p ~/.m2/repository
+fi
+
+which java 2>&1 >/dev/null ; JAVA_KNOWN=$?
+if [ ! -z "$JAVA_HOME" ] || [ $JAVA_KNOWN = "0" ]; then
+  ./mvnw install -q -f ./appsody-boot2-pom.xml
+fi

--- a/incubator/java-spring-boot2-rhr/image/project/.dockerignore
+++ b/incubator/java-spring-boot2-rhr/image/project/.dockerignore
@@ -1,0 +1,5 @@
+**/target
+**/.git
+**/.gitignore
+**/.vscode
+**/.appsody-spring-trigger

--- a/incubator/java-spring-boot2-rhr/image/project/Dockerfile
+++ b/incubator/java-spring-boot2-rhr/image/project/Dockerfile
@@ -12,8 +12,15 @@ RUN /project/util/check_version build \
 
 USER java_user
 
-####
-FROM registry.redhat.io/redhat-openjdk-18/openjdk18-openshift
+
+### Base image for app.
+
+## Requires Auth
+## FROM registry.redhat.io/redhat-openjdk-18/openjdk18-openshift
+
+## Unauthed as per https://access.redhat.com/containers/?tab=images&get-method=unauthenticated#/registry.access.redhat.com/redhat-openjdk-18/
+openjdk18-openshift
+FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
 
 ARG artifactId=appsody-spring
 ARG version=1.0-SNAPSHOT

--- a/incubator/java-spring-boot2-rhr/image/project/Dockerfile
+++ b/incubator/java-spring-boot2-rhr/image/project/Dockerfile
@@ -1,0 +1,32 @@
+FROM {{APPSODY_STACK}} as compile
+
+#setup project folder for java build step
+COPY . /project
+
+WORKDIR /project/user-app
+
+USER root
+
+RUN /project/util/check_version build \
+ && /project/java-spring-boot2-build.sh package
+
+USER java_user
+
+####
+FROM registry.redhat.io/redhat-openjdk-18/openjdk18-openshift
+
+ARG artifactId=appsody-spring
+ARG version=1.0-SNAPSHOT
+ENV JVM_ARGS=""
+
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
+LABEL org.opencontainers.image.version=${version}
+LABEL org.opencontainers.image.title=${artifactId}
+LABEL appsody.stack="kabanero/java-spring-boot2-rhr:0.1.1"
+
+COPY --from=compile /project/user-app/target/app.jar /app.jar
+
+EXPOSE 8080
+EXPOSE 8443
+
+ENTRYPOINT [ "sh", "-c", "exec java $JVM_ARGS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]

--- a/incubator/java-spring-boot2-rhr/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2-rhr/image/project/appsody-boot2-pom.xml
@@ -58,7 +58,7 @@
 
   <properties>
     <!-- Required library versions -->
-    <spring-boot-bom.version>2.1.6.Final</spring-boot-bom.version>
+    <spring-boot-bom.version>2.1.6.SP3-redhat-00001</spring-boot-bom.version>
     <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
 
     <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>

--- a/incubator/java-spring-boot2-rhr/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2-rhr/image/project/appsody-boot2-pom.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>dev.appsody</groupId>
+  <artifactId>spring-boot2-rhr</artifactId>
+  <version>{{MAVEN_ARTIFACT_VERSION}}</version>
+  <packaging>pom</packaging>
+
+  <name>Appsody Spring Boot2 stack for Kabanero </name>
+  <description>Parent POM file for Kabanero project to facilitate usage of Spring Boot on OpenShift.</description>
+  <url>https://appsody.dev</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <!-- order of precedence of the artifact’s version is:
+    * The version of the artifact’s direct declaration in project pom
+    * The version of the artifact in the parent project
+    * The version in the imported pom, taking into consideration the order of importing files
+    * dependency mediation
+
+    * If the same artifact is defined with different versions in 2 imported BOMs,
+      then the version in the BOM file that was declared first will win
+  -->
+
+  <properties>
+    <!-- Required library versions -->
+    <spring-boot-bom.version>2.1.6.Final</spring-boot-bom.version>
+    <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+
+    <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>
+
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+
+    <kotlin.version>1.2.71</kotlin.version>
+    <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <!-- properties imported from spring-boot-dependencies for ${spring-boot.version} 
+         stack build process will test and ensure these remain in sync. -->
+		<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
+		<maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
+		<maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+		<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+		<maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+		<maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+		<maven-invoker-plugin.version>3.1.0</maven-invoker-plugin.version>
+		<maven-help-plugin.version>3.1.1</maven-help-plugin.version>
+		<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+		<maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+		<maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
+		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-war-plugin.version>3.2.3</maven-war-plugin.version>    
+     
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- required dependency versions -->
+      <dependency>
+        <groupId>me.snowdrop</groupId>
+        <artifactId>spring-boot-bom</artifactId>
+        <version>${spring-boot-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>      
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Core -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!--Monitoring -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+
+    <!-- Distributed tracing with OpenTracing -->
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
+      <version>${opentracing-spring-jaeger-web-starter.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <!-- ensure fixed archive name so multistage build can find app archive -->
+    <finalName>app</finalName>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>enforce-banned-dependencies</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes>
+                      <exclude>org.springframework.boot:spring-boot-starter-web</exclude>
+                    </excludes>
+                    <includes>
+                      <include>org.springframework.boot:spring-boot-starter-web:${spring-boot.version}</include>
+                    </includes>
+                  </bannedDependencies>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${maven-clean-plugin.version}</version>
+          <configuration>
+            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+            <filesets>
+              <fileset>
+                <directory>${project.build.outputDirectory}</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+              </fileset>
+            </filesets>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <!-- Activate Spring developer tools when using appsody -->
+    <profile>
+        <id>dev</id>
+        <activation>
+          <property>
+            <name>env.APPSODY_DEV_MODE</name>
+          </property>
+        </activation>
+        <dependencies>
+          <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <optional>true</optional>
+          </dependency>
+        </dependencies>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <version>1.1</version>
+              <executions>
+                <execution>
+                  <id>trigger-spring-restart</id>
+                  <phase>compile</phase>
+                  <goals>
+                    <goal>run</goal>
+                  </goals>
+                  <configuration>
+                    <tasks>
+                      <echo>Triggering Spring app restart.</echo>
+                      <touch file="${basedir}/target/.appsody-spring-trigger" />
+                    </tasks>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/incubator/java-spring-boot2-rhr/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2-rhr/image/project/appsody-boot2-pom.xml
@@ -20,6 +20,32 @@
     </license>
   </licenses>
 
+  <repositories>
+    <repository>
+      <id>redhat-early-access</id>
+      <name>Red Hat Early Access Repository</name>
+      <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
+    </repository>
+    <repository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>redhat-early-access</id>
+      <name>Red Hat Early Access Repository</name>
+      <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </pluginRepository>
+  </pluginRepositories>  
+
   <!-- order of precedence of the artifact’s version is:
     * The version of the artifact’s direct declaration in project pom
     * The version of the artifact in the parent project

--- a/incubator/java-spring-boot2-rhr/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2-rhr/image/project/java-spring-boot2-build.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+if [ -n "$TERM" ] && [ "$TERM" != "dumb" ] && [ -x /usr/bin/tput ] && [[ `tput colors` != "0" ]]; then
+  color_prompt="yes"
+else
+  color_prompt=
+fi
+
+if [[ "$color_prompt" == "yes" ]]; then
+       BLUE="\033[0;34m"
+      GREEN="\033[0;32m"
+      WHITE="\033[1;37m"
+        RED="\033[0;31m"
+     YELLOW="\033[0;33m"
+   NO_COLOR="\033[0m"
+  MVN_COLOR=""
+else
+        BLUE=""
+      GREEN=""
+      WHITE=""
+        RED=""
+   NO_COLOR=""
+  MVN_COLOR="-Dstyle.color=never"
+fi
+
+note() {
+  echo -e "${BLUE}$@${NO_COLOR}"
+}
+warn() {
+  echo -e "${YELLOW}$@${NO_COLOR}"
+}
+error() {
+  echo -e "${RED}$@${NO_COLOR}"
+}
+
+run_mvn () {
+  echo -e "${GREEN}> mvn $@${NO_COLOR}"
+  mvn --no-transfer-progress ${MVN_COLOR} "$@"
+}
+
+common() {
+  # Test pom.xml is present and a file.
+  if [ ! -f ./pom.xml ]; then
+    error "Could not find Maven pom.xml
+
+    * The project directory (containing an .appsody-conf.yaml file) must contain a pom.xml file.
+    * On Windows and MacOS, the project directory should also be shared with Docker:
+      - Win: https://docs.docker.com/docker-for-windows/#shared-drives
+      - Mac: https://docs.docker.com/docker-for-mac/#file-sharing
+    "
+    exit 1
+  fi
+  # workaround: exit with error if repository does not exist
+  if [ ! -d /mvn/repository ]; then
+    error "Could not find local Maven repository
+
+    Create a .m2/repository directory in your home directory. For example:
+    * linux:   mkdir -p ~/.m2/repository
+    * windows: mkdir %SystemDrive%%HOMEPATH%\.m2\repository
+    "
+    exit 1
+  fi
+
+  # Get parent pom information (appsody-boot2-pom.xml)
+  local a_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:groupId" /project/appsody-boot2-pom.xml)
+  local a_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:artifactId" /project/appsody-boot2-pom.xml)
+  local a_version=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:version" /project/appsody-boot2-pom.xml)
+  local a_major=$(echo ${a_version} | cut -d'.' -f1)
+  local a_minor=$(echo ${a_version} | cut -d'.' -f2)
+  ((next=a_minor+1))
+  local a_range="[${a_major}.${a_minor},${a_major}.${next})"
+
+  if ! $(mvn -N dependency:get -q -o -Dartifact=${a_groupId}:${a_artifactId}:${a_version} -Dpackaging=pom >/dev/null)
+  then
+    # Install parent pom
+    note "Installing parent ${a_groupId}:${a_artifactId}:${a_version}"
+    run_mvn install -q -f /project/appsody-boot2-pom.xml
+  fi
+
+  local p_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:groupId" pom.xml)
+  local p_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:artifactId" pom.xml)
+  local p_version_range=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:version" pom.xml)
+
+  # Require parent in pom.xml
+  if [ "${p_groupId}" != "${a_groupId}" ] || [ "${p_artifactId}" != "${a_artifactId}" ]; then
+    error "Project pom.xml is missing the required parent:
+
+    <parent>
+      <groupId>${a_groupId}</groupId>
+      <artifactId>${a_artifactId}</artifactId>
+      <version>${a_range}</version>
+      <relativePath/>
+    </parent>
+    "
+    exit 1
+  fi
+
+  if ! /project/util/check_version contains "$p_version_range" "$a_version";  then
+    error "Version mismatch
+
+The version of the appsody stack '${a_version}' does not match the
+parent version specified in pom.xml '${p_version_range}'. Please update
+the parent version in pom.xml, and test your changes.
+
+    <parent>
+      <groupId>${a_groupId}</groupId>
+      <artifactId>${a_artifactId}</artifactId>
+      <version>${a_range}</version>
+      <relativePath/>
+    </parent>
+    "
+    exit 1
+  fi
+}
+
+recompile() {
+  note "Compile project in the foreground"
+  run_mvn compile
+}
+
+package() {
+  note "Package project in the foreground"
+  run_mvn clean package verify
+}
+
+debug() {
+  note "Build and debug project in the foreground"
+  run_mvn -Dmaven.test.skip=true \
+    -Dspring-boot.run.jvmArguments='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005' \
+    spring-boot:run
+}
+
+run() {
+  note "Build and run project in the foreground"
+  run_mvn -Dmaven.test.skip=true \
+    clean spring-boot:run
+}
+
+test() {
+  note "Test project in the foreground"
+  run_mvn package test
+}
+
+#set the action, default to fail text if none passed.
+ACTION=
+if [ $# -ge 1 ]; then
+  ACTION=$1
+  shift
+fi
+
+case "${ACTION}" in
+  recompile)
+    export APPSODY_DEV_MODE=run
+    recompile
+  ;;
+  package)
+    common
+    package
+  ;;
+  debug)
+    common
+    export APPSODY_DEV_MODE=debug
+    debug
+  ;;
+  run)
+    common
+    export APPSODY_DEV_MODE=run
+    run
+  ;;
+  test)
+    common
+    export APPSODY_DEV_MODE=test
+    test
+  ;;
+  *)
+    error "Unexpected script usage, expected one of recompile, package, debug, run, test"
+  ;;
+esac

--- a/incubator/java-spring-boot2-rhr/image/project/util/RangeIncludesVersion.java
+++ b/incubator/java-spring-boot2-rhr/image/project/util/RangeIncludesVersion.java
@@ -1,0 +1,17 @@
+import org.osgi.framework.VersionRange;
+import org.osgi.framework.Version;
+
+public class RangeIncludesVersion {
+
+    public static void main(String[] args) {
+        if ( args.length < 2 ) {
+            System.out.println("Must specify range and version");
+            System.exit(1);
+        }
+        String range = args[0];
+        String version = args[1];
+
+        boolean result = VersionRange.valueOf(range).includes(Version.valueOf(version));
+        System.exit( result ? 0 : 1 );
+    }
+}

--- a/incubator/java-spring-boot2-rhr/image/project/util/check_version
+++ b/incubator/java-spring-boot2-rhr/image/project/util/check_version
@@ -1,0 +1,48 @@
+#!/bin/bash
+# This is a small utility script that uses OSGi VersionRange and Version
+# classes to verify whether or not a specified version matches is contained
+# within a specified range.
+#
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+if [ $# -lt 1 ]; then
+    ACTION=range
+else
+    ACTION=$1
+    shift
+fi
+
+range_check() {
+    java -cp .:org.osgi.core-6.0.0.jar RangeIncludesVersion "$1" "$2"
+    return $?
+}
+
+sniff() {
+    range_check "$1" "$2"
+    if [ $? -ne $3 ]; then
+        echo "Test |'$1' contains '$2'| should return $3. Got $?"
+        exit 1
+    fi
+}
+
+case "$ACTION" in
+  build)
+    wget -q https://repo1.maven.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar
+    javac -cp org.osgi.core-6.0.0.jar *.java
+
+    sniff "[0.3,0.4)" "0.3.7" 0
+    sniff "[0.3,0.4)" "0.4" 1
+    sniff "[0.3,0.4)" "0.2" 1
+    exit 0
+  ;;
+  contains)
+    if [ $# -lt 2 ]; then
+        echo "Specify version information: check_version contains <range_spec> <version>"
+        exit 1
+    fi
+
+    range_check "$1" "$2"
+    exit $?
+  ;;
+esac
+

--- a/incubator/java-spring-boot2-rhr/image/project/verify-property-versions.sh
+++ b/incubator/java-spring-boot2-rhr/image/project/verify-property-versions.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Where is the parent pom located?
+PARENT_POM=/project/appsody-boot2-pom.xml
+
+# Read the Spring boot version from our parent pom
+SPRING_BOOT_VERSION=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:properties/x:spring-boot.version" $PARENT_POM)
+# Obtain matching spring-boot-dependencies pom
+curl -s "https://raw.githubusercontent.com/spring-projects/spring-boot/v${SPRING_BOOT_VERSION}/spring-boot-project/spring-boot-dependencies/pom.xml" -o /tmp/springdeps.xml
+
+# Collect all property elements from spring pom and our pom
+xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -m "/x:project/x:properties/child::node()" -v "name()" -n /tmp/springdeps.xml > /tmp/springprops
+xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -m "/x:project/x:properties/child::node()" -v "name()" -n $PARENT_POM > /tmp/parentprops
+
+# Remember the intersection of the property element names
+grep -Fxf /tmp/springprops /tmp/parentprops > /tmp/matchingprops
+
+RC=0
+# Compare the value of interesected property names, report mismatches.
+for prop in $(cat /tmp/matchingprops); do
+  echo -n "Evaluating $prop "
+  PARENTVER=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:properties/x:$prop" $PARENT_POM)
+  SPRINGVER=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:properties/x:$prop" /tmp/springdeps.xml)
+  if [ "$PARENTVER" != "$SPRINGVER" ]; then
+    echo ".. Mismatch !!  Spring: $SPRINGVER Parent: $PARENTVER"
+    RC=1
+  else
+    echo ".. OK( $PARENTVER )"
+  fi
+done
+
+# Report Pass/Fail for log
+if [ "$RC" == "1" ]; then
+  echo "FAIL: Properties used to control dependency/plugin versions are not in agreement between this stack and the corresponding spring-boot-dependencies artifact."
+  echo "      This must be corrected before the stack may be released"
+else
+  echo "PASS."
+fi
+
+# Clean up all temp files.
+rm /tmp/matchingprops /tmp/springprops /tmp/parentprops /tmp/springdeps.xml
+
+# convey success/failure via return code.
+exit $RC

--- a/incubator/java-spring-boot2-rhr/pipelines/.gitkeep
+++ b/incubator/java-spring-boot2-rhr/pipelines/.gitkeep
@@ -1,0 +1,1 @@
+Keep this file so that directory remains

--- a/incubator/java-spring-boot2-rhr/stack.yaml
+++ b/incubator/java-spring-boot2-rhr/stack.yaml
@@ -1,0 +1,13 @@
+name: Spring Boot® RHR
+version: 0.1.1
+description: Spring Boot using RHR and Maven
+license: Apache-2.0
+language: java
+maintainers:
+  - name: Erin Schnabel
+    email: schnabel@us.ibm.com
+    github-id: ebullient
+  - name: Ozzy Osborne
+    email: ozzy@ca.ibm.com
+    github-id: bardweller    
+default-template: default

--- a/incubator/java-spring-boot2-rhr/templates/default/.gitignore
+++ b/incubator/java-spring-boot2-rhr/templates/default/.gitignore
@@ -1,0 +1,28 @@
+/target/*
+.appsody-spring-trigger
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+/build/
+
+### VS Code ###
+.vscode/

--- a/incubator/java-spring-boot2-rhr/templates/default/pom.xml
+++ b/incubator/java-spring-boot2-rhr/templates/default/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent><!--required parent POM-->
+    <groupId>dev.appsody</groupId>
+    <artifactId>spring-boot2-rhr</artifactId>
+    <version>[0.1, 0.2)</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>dev.appsody</groupId>
+  <artifactId>default-application</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <!-- versions will come from the parent pom (and included bom):
+    mvn dependency:tree
+    mvn dependency:display-ancestors
+    mvn help:effective-pom | grep '\.version>'
+    -->
+
+  <dependencies>
+    <!-- From parent:
+      org.springframework.boot:spring-boot-starter
+      org.springframework.boot:spring-boot-starter-actuator
+      org.springframework.boot:spring-boot-starter-test
+     -->
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/incubator/java-spring-boot2-rhr/templates/default/src/main/java/application/LivenessEndpoint.java
+++ b/incubator/java-spring-boot2-rhr/templates/default/src/main/java/application/LivenessEndpoint.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package application;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+// Simple custom liveness check
+@Endpoint(id = "liveness")
+@Component
+public class LivenessEndpoint {
+
+    @ReadOperation
+    public String testLiveness() {
+        return "{\"status\":\"UP\"}";
+    }
+
+}

--- a/incubator/java-spring-boot2-rhr/templates/default/src/main/java/application/Main.java
+++ b/incubator/java-spring-boot2-rhr/templates/default/src/main/java/application/Main.java
@@ -1,0 +1,13 @@
+package application;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Main.class, args);
+	}
+
+}

--- a/incubator/java-spring-boot2-rhr/templates/default/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2-rhr/templates/default/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+#enable the actuator endpoints for health, metrics, and prometheus.
+management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
+spring.devtools.restart.additional-paths=./target
+spring.devtools.restart.trigger-file=.appsody-spring-trigger

--- a/incubator/java-spring-boot2-rhr/templates/default/src/main/resources/public/index.html
+++ b/incubator/java-spring-boot2-rhr/templates/default/src/main/resources/public/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello from Appsody!</title>
+  </head>
+  <body>
+    <h3>Hello from Appsody!</h3>
+    <p>Next steps with Spring Boot 2:
+      <ul>
+        <li><a target="_blank" rel="noopener" href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot Reference Guide</a></li>
+        <li><a target="_blank" rel="noopener" href="https://spring.io/guides">Spring Guides</a></li>
+        <li><a target="_blank" rel="noopener" href="/actuator">Spring Boot Actuator endpoints</a>:
+          <ul>
+            <li><a target="_blank" rel="noopener" href="/actuator/health">Health</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/liveness">Liveness</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/metrics">Metrics</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/prometheus">Prometheus</a></li>
+          </ul>
+        </li>
+      </ul>
+    </p>
+  </body>
+</html>

--- a/incubator/java-spring-boot2-rhr/templates/default/src/test/java/application/MainTests.java
+++ b/incubator/java-spring-boot2-rhr/templates/default/src/test/java/application/MainTests.java
@@ -1,0 +1,61 @@
+package application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class MainTests {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void testHealthEndpoint() {
+        ResponseEntity<String> entity = this.restTemplate.getForEntity("/actuator/health", String.class);
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    public void testLivenessEndpoint() {
+        ResponseEntity<String> entity = this.restTemplate.getForEntity("/actuator/liveness", String.class);
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getBody()).contains("\"status\":\"UP\"");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testMetricsEndpoint() {
+        testLivenessEndpoint(); // access a page
+
+        @SuppressWarnings("rawtypes")
+        ResponseEntity<Map> entity = this.restTemplate.getForEntity("/actuator/metrics", Map.class);
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        Map<String, Object> body = entity.getBody();
+        assertThat(body).containsKey("names");
+        assertThat((List<String>) body.get("names")).contains("jvm.buffer.count");
+    }
+
+    @Test
+    public void testPrometheusEndpoint() {
+        testLivenessEndpoint(); // access a page
+
+        ResponseEntity<String> entity = this.restTemplate.getForEntity("/actuator/prometheus", String.class);
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getBody()).contains("# TYPE jvm_buffer_count_buffers gauge");
+    }
+}

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/.gitignore
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/.gitignore
@@ -1,0 +1,28 @@
+/target/*
+.appsody-spring-trigger
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+/build/
+
+### VS Code ###
+.vscode/

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/pom.xml
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent><!--required parent POM-->
+    <groupId>dev.appsody</groupId>
+    <artifactId>spring-boot2-rhr</artifactId>
+    <version>[0.1, 0.2)</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>dev.appsody</groupId>
+  <artifactId>kotlin-application</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <!-- versions will come from the parent pom (and included bom):
+    mvn dependency:tree
+    mvn dependency:display-ancestors
+    mvn help:effective-pom | grep '\.version>'
+    -->
+
+  <dependencies>
+    <!-- From parent:
+      org.springframework.boot:spring-boot-starter
+      org.springframework.boot:spring-boot-starter-actuator
+      org.springframework.boot:spring-boot-starter-test
+     -->
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-reflect</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <executions>
+          <execution>
+              <id>compile</id>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <configuration>
+                  <sourceDirs>
+                      <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                      <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                  </sourceDirs>
+              </configuration>
+          </execution>
+          <execution>
+              <id>test-compile</id>
+              <goals>
+                <goal>test-compile</goal>
+              </goals>
+              <configuration>
+                  <sourceDirs>
+                      <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                      <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                  </sourceDirs>
+              </configuration>
+          </execution>
+        </executions>
+        <configuration>
+           <args>
+              <arg>-Xjsr305=strict</arg>
+           </args>
+           <compilerPlugins>
+              <plugin>spring</plugin>
+           </compilerPlugins>
+        </configuration>
+        <dependencies>
+           <dependency>
+              <groupId>org.jetbrains.kotlin</groupId>
+              <artifactId>kotlin-maven-allopen</artifactId>
+              <version>${kotlin.version}</version>
+           </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.5.1</version>
+          <executions>
+              <execution>
+                  <id>default-compile</id>
+                  <phase>none</phase>
+              </execution>
+              <execution>
+                  <id>default-testCompile</id>
+                  <phase>none</phase>
+              </execution>
+              <execution>
+                  <id>java-compile</id>
+                  <phase>compile</phase>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+              </execution>
+              <execution>
+                  <id>java-test-compile</id>
+                  <phase>test-compile</phase>
+                  <goals>
+                    <goal>testCompile</goal>
+                  </goals>
+              </execution>
+          </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/kotlin/application/Hello.kt
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/kotlin/application/Hello.kt
@@ -1,0 +1,13 @@
+package application
+
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.GetMapping
+
+@RestController
+class Hello {
+
+    @GetMapping("/hello")
+    fun hello(): String {
+        return "Hello, Appsody!"
+    }
+}

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/kotlin/application/LivenessEndpoint.kt
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/kotlin/application/LivenessEndpoint.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2019 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+package application
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation
+import org.springframework.stereotype.Component
+
+// Simple custom liveness check
+@Endpoint(id = "liveness")
+@Component
+class LivenessEndpoint {
+
+    @ReadOperation
+    fun testLiveness(): String {
+        return "{\"status\":\"UP\"}"
+    }
+}

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/kotlin/application/Main.kt
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/kotlin/application/Main.kt
@@ -1,0 +1,12 @@
+package application
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class Main
+
+fun main(args: Array<String>) {
+    runApplication<Main>(*args)
+}
+

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+#enable the actuator endpoints for health, metrics, and prometheus.
+management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
+spring.devtools.restart.additional-paths=./target
+spring.devtools.restart.trigger-file=.appsody-spring-trigger

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/resources/public/index.html
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/src/main/resources/public/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello from Appsody!</title>
+  </head>
+  <body>
+    <h3>Hello from Appsody!</h3>
+    <p>Next steps with Spring Boot 2:
+      <ul>
+        <li><a target="_blank" rel="noopener" href="https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/">Spring Boot Reference Guide</a></li>
+        <li><a target="_blank" rel="noopener" href="https://spring.io/guides">Spring Guides</a></li>
+        <li><a target="_blank" rel="noopener" href="/actuator">Spring Boot Actuator endpoints</a>:
+          <ul>
+            <li><a target="_blank" rel="noopener" href="/actuator/health">Health</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/liveness">Liveness</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/metrics">Metrics</a></li>
+            <li><a target="_blank" rel="noopener" href="/actuator/prometheus">Prometheus</a></li>
+          </ul>
+        </li>
+      </ul>
+    </p>
+  </body>
+</html>

--- a/incubator/java-spring-boot2-rhr/templates/kotlin/src/test/kotlin/application/MainTests.kt
+++ b/incubator/java-spring-boot2-rhr/templates/kotlin/src/test/kotlin/application/MainTests.kt
@@ -1,0 +1,50 @@
+package application
+
+import kotlin.collections.List
+import kotlin.collections.Map
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.junit4.SpringRunner
+
+@RunWith(SpringRunner::class)
+@SpringBootTest(
+    classes = arrayOf(Main::class),
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class MainTests {
+    var result = """{"status":"UP"}"""
+
+    @Autowired
+    lateinit var restTemplate: TestRestTemplate
+
+    @Test
+    fun healthCheck_shouldReturnUP() {
+        val entity = restTemplate.getForEntity("/actuator/health", String::class.java)
+
+        assertNotNull(entity)
+        assertEquals(HttpStatus.OK, entity.statusCode)
+
+        assertNotNull(entity.body)
+        assertEquals(result, entity.body)
+    }
+
+    @Test
+    fun liveness_shouldReturnUP() {
+        val entity = restTemplate.getForEntity("/actuator/liveness", String::class.java)
+
+        assertNotNull(entity)
+        assertEquals(HttpStatus.OK, entity.statusCode)
+
+        assertNotNull(entity.body)
+        assertEquals(result, entity.body)
+    }
+
+}


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Added first pass at an RHR stack for Spring Boot (use a diff tool to view changes from `java-spring-boot2` if you want to minimise review overhead).

Quick summary of differences:
- Name & Version changed (I think I got all of them, Kabanero seems to have added a few beyond the one in use by appsody)
- Parent pom artifact rename to avoid class with existing stack
- All templates updated to reference new parent pom artifact name
- Parent pom no longer has spring boot pom as parent, now uses snowdrop bom
- Parent pom has to declare a bunch of properties used to version plugins/dependencies that were previously set by spring boot parent pom. Extra stack build step added to verify those properties retain the values that would have been defined by the corresponding parent pom. 
- `kotlin.version` has been altered to agree with spring boot parent pom version.
- Final build image set to use RHR image as a base. *see note below!!*

**Note:** PR is draft, as the final image requires Red Hat creds to pull, which means the current build system is unlikely to be able to verify the `appsody build` step until it's taught how to handle that. 

### Related Issues:
