### PR TITLE
Update image registry URL.

### DIFF
--- a/incubator/triggers/eventTriggers.yaml
+++ b/incubator/triggers/eventTriggers.yaml
@@ -14,7 +14,7 @@ variables:
   - name: build.tag.promoteNamespaceSuffix # suffix for promoted namespace. Default is project-test.
     value: '"-test"'
   - name: build.registry
-    value: ' "docker-registry.default.svc:5000" '
+    value: ' "image-registry.openshift-image-registry.svc:5000" '
   - name: build.namespace
     value: ' kabanero.namespace ' 
   - name: build.serviceAccount


### PR DESCRIPTION
### Checklist:
- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

## Updates to the collections
From OpenShift 3.11 to 4.2, the internal image registry moved from `docker-registry.default.svc` to `image-registry.openshift-image-registry.svc`. The triggers collection should be updated to push to the correct internal registry service.

### Related Issues:
None.