### PR TITLE
Update liberty version for java-microprofile

### DIFF
--- a/incubator/java-microprofile/README.md
+++ b/incubator/java-microprofile/README.md
@@ -4,7 +4,7 @@ The Java MicroProfile stack provides a consistent way of developing microservice
 
 The Java MicroProfile stack uses a parent Maven project object model (POM) to manage dependency versions and provide required capabilities and plugins.
 
-This stack is based on OpenJDK with container-optimizations in OpenJ9 and `Open Liberty v19.0.0.8`. It provides live reloading during development by utilizing `loose application` capabilities.
+This stack is based on OpenJDK with container-optimizations in OpenJ9 and `Open Liberty v19.0.0.9`. It provides live reloading during development by utilizing `loose application` capabilities.
 
 The stack also provides a in-built application monitoring dashboard based on [javametrics](https://github.com/runtimetools/javametrics). This dashboard is only included during development and is not included in the image built using `appsody build`.
 

--- a/incubator/java-microprofile/image/project/pom.xml
+++ b/incubator/java-microprofile/image/project/pom.xml
@@ -30,7 +30,7 @@
         <!-- OpenLiberty runtime -->
         <liberty.groupId>io.openliberty</liberty.groupId>
         <liberty.artifactId>openliberty-runtime</liberty.artifactId>
-        <version.openliberty-runtime>19.0.0.8</version.openliberty-runtime>
+        <version.openliberty-runtime>19.0.0.9</version.openliberty-runtime>
         <http.port>9080</http.port>
         <https.port>9443</https.port>
         <packaging.type>usr</packaging.type>
@@ -66,8 +66,8 @@
                             </requireJavaVersion>
                             <requireProperty>
                                 <property>version.openliberty-runtime</property>
-                                <regex>19.0.0.8</regex>
-                                <regexMessage>OpenLiberty runtime version must be 19.0.0.8</regexMessage>
+                                <regex>19.0.0.9</regex>
+                                <regexMessage>OpenLiberty runtime version must be 19.0.0.9</regexMessage>
                             </requireProperty>
                         </rules>
                     </configuration>


### PR DESCRIPTION
This PR set's the libberty version for the development and build containers to be the same as the deploy container.