### PR TITLE
java-spring-boot: Dockerfile uses UBI for final stage

### DIFF
--- a/incubator/java-spring-boot2/image/config/app-deploy.yaml
+++ b/incubator/java-spring-boot2/image/config/app-deploy.yaml
@@ -17,7 +17,7 @@ spec:
     labels:
       k8s-app: APPSODY_PROJECT_NAME
     endpoints:
-    - path: '/actuator/prometheus'        
+    - path: '/actuator/prometheus'
   readinessProbe:
     failureThreshold: 12
     httpGet:

--- a/incubator/java-spring-boot2/image/project/.appsody-init.bat
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.bat
@@ -1,10 +1,14 @@
 if not exist %SystemDrive%%HOMEPATH%\.m2\repository\ (
   mkdir %SystemDrive%%HOMEPATH%\.m2\repository
 )
-setlocal
-set JAVA_FOUND=0
-where java >nul 2>nul
-if %ERRORLEVEL% EQU 0 set JAVA_FOUND=1
-if defined JAVA_HOME set JAVA_FOUND=1
-if "%JAVA_FOUND%"==1 mvnw install -q -f ./appsody-boot2-pom.xml
 
+copy mvnw*.* .. >nul
+mkdir ..\.mvn
+robocopy .mvn ..\.mvn /e /njh /njs /ndl /nc /ns >nul
+
+where java >nul 2>nul
+if %ERRORLEVEL% EQU 0 (
+  if defined JAVA_HOME (
+    ..\mvnw install -q -f ./appsody-boot2-pom.xml
+  )
+)

--- a/incubator/java-spring-boot2/image/project/.appsody-init.sh
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.sh
@@ -22,3 +22,7 @@ which java 2>&1 >/dev/null ; JAVA_KNOWN=$?
 if [ ! -z "$JAVA_HOME" ] || [ $JAVA_KNOWN = "0" ]; then
   ./mvnw install -q -f ./appsody-boot2-pom.xml
 fi
+
+# copy the maven wrapper from the stack to extracted application directory
+cp -Rp mvnw* ..
+cp -Rp .mvn ..

--- a/incubator/java-spring-boot2/image/project/Dockerfile
+++ b/incubator/java-spring-boot2/image/project/Dockerfile
@@ -14,15 +14,22 @@ USER java_user
 
 ### Base image for app.
 
-### RHR
+### Red Hat Runtime image based on RHEL. Requires subscription.
 ## Requires Auth
 ## FROM registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7
 ## Unauthed as per https://access.redhat.com/containers/?tab=images&get-method=unauthenticated#/registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
-FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.7
+#FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.7
+
+FROM kabanero/ubi8-openjdk:0.3.0
 
 ENV JVM_ARGS=""
 
+RUN groupadd --gid 1000 java_group \
+  && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
+
 COPY --from=compile /project/user-app/target/app.jar /app.jar
+
+USER java_user
 
 EXPOSE 8080
 EXPOSE 8443

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-pom.xml
@@ -44,7 +44,7 @@
       <name>Red Hat GA Repository</name>
       <url>https://maven.repository.redhat.com/ga/</url>
     </pluginRepository>
-  </pluginRepositories>  
+  </pluginRepositories>
 
   <!-- order of precedence of the artifact’s version is:
     * The version of the artifact’s direct declaration in project pom

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -73,7 +73,12 @@ common() {
   then
     # Install parent pom
     note "Installing parent ${a_groupId}:${a_artifactId}:${a_version}"
-    run_mvn install -q -f /project/appsody-boot2-pom.xml
+    if [ -z "${APPSODY_DEV_MODE}" ]
+    then
+        run_mvn install -f /project/appsody-boot2-pom.xml
+    else
+        run_mvn install -q -f /project/appsody-boot2-pom.xml
+    fi
   fi
 
   local p_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:groupId" pom.xml)

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.17
+version: 0.3.18
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ ] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections

Use the UBI image as a base image for the final stage in the kabanero collection.

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->