### PR TITLE
Change default value for LATEST_RELEASE if not set

### DIFF
--- a/ci/ext/pre_env.d/kabanero_pre_env.sh
+++ b/ci/ext/pre_env.d/kabanero_pre_env.sh
@@ -26,6 +26,5 @@ then
     export IMAGE_REGISTRY_ORG="kabanero"
 fi
 if [ -z "$LATEST_RELEASE" ]; then
-    export LATEST_RELEASE=false
+    export LATEST_RELEASE=true
 fi
-


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

## Updates to the collections
<!--- Describe your changes in detail -->
Updated the CI scripts to not set a default value for the LATEST_RELEASE environment variable

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->
Fixes https://github.com/kabanero-io/collections/issues/213