### PR TITLE
Quote and use braces in envvar checks.

### DIFF
--- a/ci/ext/pre_env.d/kabanero_pre_env.sh
+++ b/ci/ext/pre_env.d/kabanero_pre_env.sh
@@ -2,35 +2,35 @@
 set -e
 
 # Setup the environment variable needed to build Kabanero Collections
-if [ -z $BUILD_ALL ]; then
+if [ -z "${BUILD_ALL}" ]; then
     export BUILD_ALL=true
 fi
-if [ -z $REPO_LIST ]; then
+if [ -z "${REPO_LIST}" ]; then
     export REPO_LIST=incubator
 fi
-if [ -z $EXCLUDED_STACKS ]; then
+if [ -z "${EXCLUDED_STACKS}" ]; then
     export EXCLUDED_STACKS=""
 fi
-if [ -z $CODEWIND_INDEX ]; then
+if [ -z "${CODEWIND_INDEX}" ]; then
     export CODEWIND_INDEX=true
 fi
-if [ -z $INDEX_IMAGE ]; then
+if [ -z "${INDEX_IMAGE}" ]; then
     export INDEX_IMAGE=kabanero-index
-fi 
-if [ -z "$DISPLAY_NAME_PREFIX" ]
+fi
+if [ -z "${DISPLAY_NAME_PREFIX}" ]
 then
     export DISPLAY_NAME_PREFIX="Kabanero"
 fi
-if [ -z "$IMAGE_REGISTRY_ORG" ]
+if [ -z "${IMAGE_REGISTRY_ORG}" ]
 then
     export IMAGE_REGISTRY_ORG="kabanero"
 fi
-if [ -z "$LATEST_RELEASE" ]; then
+if [ -z "${LATEST_RELEASE}" ]; then
     export LATEST_RELEASE=false
 fi
 # Temporary change to force latest release to be true
 # This will normally be determined and set in another script
 # based on whether a later release exists or not. This is not
-# written yet so we need to hardcode this value.  
+# written yet so we need to hardcode this value.
 export LATEST_RELEASE=true
 


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Excluding more than one stack using `EXCLUDED_STACKS` causes a warning to be printed out when trying to build collections. The warning is probably harmless though since all the if block does is set a default value and its only failing when the env var already has been set.

Warning encountered when running `ci/build.sh` when `EXCLUDED_STACKS=incubator/java-spring-boot2 incubator/nodejs-express incubator/nodejs-loopback incubator/nodejs`:
```shell
+ '[' -z incubator/java-spring-boot2 incubator/nodejs-express incubator/nodejs-loopback incubator/nodejs ']'
ci/ext/pre_env.d/kabanero_pre_env.sh: line 11: [: too many arguments
```

This change quotes all variable checks to properly handle space-delimited values and surrounded variable expansions with braces as is best-practice.

### Related Issues:
None.