### PR TITLE
use user with root group

### DIFF
--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -4,14 +4,10 @@ USER root
 
 # Install OS updates
 RUN yum upgrade --disableplugin=subscription-manager -y \
+ && yum install --disableplugin=subscription-manager python2 -y \
  && yum clean --disableplugin=subscription-manager packages \
- && echo 'Finished installing dependencies'
-
- RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
-
- RUN yum install --disableplugin=subscription-manager python2 -y
- RUN ln -s /usr/bin/python2 /usr/bin/python
+ && ln -s /usr/bin/python2 /usr/bin/python \
+ && useradd --uid 1000 --gid 0 --shell /bin/bash --create-home node
 
 # Install stack dependencies
 WORKDIR /project
@@ -24,7 +20,8 @@ COPY ./user-app/package*.json ./
 RUN npm install --production
 
 COPY . /project
-RUN chown -hR node:node /project
+RUN chown -hR node:0 /project \
+ && chmod -R g=u /project
 
 WORKDIR /project
 


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Follow [OpenShift guidelines](https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines) a bit closer - user with 0 group and fix up permissions - possible fix for #224. Also, reduce number of layers.
Another possible optimization is to get rid of the `node` user and just use `default` user as already defined on the base image.

### Related Issues:
#224 