### PR TITLE
Use updated pipeline names in trigger collection.

### DIFF
--- a/incubator/triggers/eventTriggers.yaml
+++ b/incubator/triggers/eventTriggers.yaml
@@ -13,7 +13,7 @@ eventTriggers:
       - build.jobid : ' jobID() '
       - build.nameSuffix: toDomainName( build.ownerLogin + "-" + build.repositoryName + "-" + build.event + "-" + build.jobid)
       - build.defaultRegistry : ' "image-registry.openshift-image-registry.svc:5000" '
-      - build.serviceAccount : ' "kabanero-operator" '
+      - build.serviceAccountName : ' "kabanero-operator" '
 
       #### Push ####
       - if: ' build.event == "push" '

--- a/incubator/triggers/pull/run.yaml
+++ b/incubator/triggers/pull/run.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{.namespace}}
 spec:
   pipelineRef:
-    name: {{.collectionID}}-build-pipeline
+    name: {{.collectionID}}-build-pl
   resources:
   - name: git-source
     resourceRef:
       name: git-{{.nameSuffix}}
-  serviceAccount: {{.serviceAccount}}
+  serviceAccountName: {{.serviceAccountName}}
   timeout: {{.timeout}}

--- a/incubator/triggers/push/run.yaml
+++ b/incubator/triggers/push/run.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{.namespace}}
 spec:
   pipelineRef:
-    name: {{.collectionID}}-build-push-pipeline
+    name: {{.collectionID}}-build-push-pl
   resources:
   - name: git-source
     resourceRef:
@@ -13,5 +13,5 @@ spec:
   - name: docker-image
     resourceRef:
       name: docker-{{.nameSuffix}}
-  serviceAccount: {{.serviceAccount}}
+  serviceAccountName: {{.serviceAccountName}}
   timeout: {{.timeout}}

--- a/incubator/triggers/tag/run.yaml
+++ b/incubator/triggers/tag/run.yaml
@@ -4,10 +4,10 @@ metadata:
   name: {{.nameSuffix}}
   namespace: {{.namespace}}
 spec:
-  serviceAccount: {{.serviceAccount}}
+  serviceAccountName: {{.serviceAccountName}}
   timeout: 
   pipelineRef:
-    name: {{.collectionID}}-image-retag-push-pipeline
+    name: {{.collectionID}}-image-retag-pl
   resources:
     - name: docker-src-image
       resourceRef:


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).

## Updates to the collections
The pipeline names were shortened in the pipelines [PR 161](https://github.com/kabanero-io/kabanero-pipelines/pull/161). Triggers was updated to use the shortened pipeline names. Also, the `seriveAccountName` change is necessary due to a Tekton change.

### Related Issues:
* kabanero-events [issue 58](https://github.com/kabanero-io/kabanero-events/issues/58)