### PR TITLE
spring boot updates for UBI images and snowdrop dependency management

### DIFF
--- a/incubator/java-spring-boot2/README.md
+++ b/incubator/java-spring-boot2/README.md
@@ -12,7 +12,7 @@ The [Spring Developer Tools](https://docs.spring.io/spring-boot/docs/current/ref
 
 Templates are used to create your local project and start your development.
 
-The default template provides a `pom.xml` file that references the parent POM defined by the stack, and a simple Spring Boot application main class that defines a basic [liveness endpoint](#health-checks-readiness-and-liveness), and a set of unit tests that ensure enabled actuator endpoints work properly: `/actuator/health`, `/actuator/metrics`, `/actuator/prometheus`, and `actuator/liveness`.
+The default template provides a `pom.xml` file that references the parent POM defined by the stack, and a simple Spring Boot application main class that defines a basic [liveness endpoint](#health-checks-readiness-and-liveness), and a set of unit tests that ensure enabled actuator endpoints work properly: `/actuator/health`, `/actuator/metrics`, `/actuator/prometheus`, and `/actuator/liveness`.
 
 ## Getting Started
 
@@ -24,7 +24,7 @@ The default template provides a `pom.xml` file that references the parent POM de
     appsody init java-spring-boot2
     ```
 
-    This will initialize a Spring Boot 2 project using the microservice template.
+    This will initialize a Spring Boot 2 project using the default template.
 
 1. Once your project has been initialized you can then run your application using the following command:
 
@@ -47,11 +47,39 @@ Kubernetes defines two integral mechanisms for checking the health of a containe
 
 * A readiness probe is used to indicate whether the process can handle requests (is routable). Kubernetes doesn't route work to a container with a failing readiness probe. A readiness probe should fail if a service hasn't finished initializing, or is otherwise busy, overloaded, or unable to process requests.
 
-* A liveness probe is used to indicate whether the process should be restarted. Kubernetes stops and restarts a container with a failing liveness probe to ensure that Pods in a defunct state are terminated and replaced. A liveness probe should fail if the service is in an irrecoverable state, for example, if an out of memory condition occurs. Simple liveness checks that always return an OK response can identify containers in an inconsistent state, which can happen when process serving requests has crashed but the container is still running.
+* A liveness probe is used to indicate whether the process should be restarted. Kubernetes stops and restarts a container with a failing liveness probe to ensure that Pods in a defunct state are terminated and replaced. A liveness probe should fail if the service is in an irrecoverable state; for example, if an out of memory condition occurs. 
 
-The Spring Boot 2 Actuator defines an `/actuator/health` endpoint, which returns a {"status": "UP"} payload when all is well. This endpoint is enabled by default, and requires no application code. This actuator works well as a Kubernetes readiness probe, as it automatically includes the status of required resources.
+The Spring Boot 2 Actuator framework defines an `/actuator/health` endpoint, which returns a {"status": "UP"} payload when all is well. This endpoint is enabled by default, and requires no application code. This actuator works well as a Kubernetes readiness probe, as it automatically indicates the status of required resources.
 
-The health endpoint is less useful as a liveness check. In Spring Boot 2, the Actuator framework can be trivially extended with custom endpoints. Your application will include a trivial endpoint to be used as a Kubernetes liveness probe.
+Spring Boot 2 Actuator does not provide a `liveness` endpoint, and the `health` endpoint is less useful as a liveness check. However, the Actuator framework can be easily extended with custom endpoints, like the example liveness endpoint provided by the application template. 
+
+    @Endpoint(id = "liveness")
+    @Component
+    public class LivenessEndpoint {
+    
+        @ReadOperation
+        public String testLiveness() {
+            return "{\"status\":\"UP\"}";
+        }
+
+Note that even a simple liveness check that always returns an OK response can help to identify containers in an inconsistent state, which can happen when a process serving requests has crashed but the container is still running.
+
+The starter application produced using this template has a Kubernetes deployment configuration that uses the Spring Boot 2 Actuator `health` endpoint as a Kubernetes `readiness` probe, and uses the template's `liveness` endpoint as a  Kubernetes `liveness` probe.
+
+## Docker image currency
+
+The stack implementation provides for two Docker image specifications, as stack variables declared in the `stack.yaml` file. These are:  
+
+    baseimage: maven:3.6-ibmjava-8
+    finalimage: adoptopenjdk/openjdk8-openj9:ubi-jre
+
+The `finalimage` specification determines the image that will be used as the base for the application image. The `baseimage` is used as the base for the stack runtime (a development tool), and also for the "prep" stage of the application image build. By default, as shown above, a Debian image is used for `baseimage` and a Red Hat UBI image is used for `finalimage`. 
+
+The stack implementation provides for optionally updating the packages in these images during the Docker build. By default, the UBI base for the `finalimage` is not updated, while the stack image on the other hand does get updated during a build of the stack itself. 
+
+For more information about UBI see:
+[Introducing the Red Hat Universal Base Image](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image)
+ 
 
 ## License
 

--- a/incubator/java-spring-boot2/README.md
+++ b/incubator/java-spring-boot2/README.md
@@ -1,4 +1,4 @@
-# Spring® Boot 2 Stack 
+# Spring® Boot 2 Stack
 
 The Spring Boot 2 stack supports the development of [Spring Boot 2](https://spring.io/projects/spring-boot) applications using OpenJDK 8 and OpenJ9 from [AdoptOpenJDK](https://adoptopenjdk.net/).
 

--- a/incubator/java-spring-boot2/README.md
+++ b/incubator/java-spring-boot2/README.md
@@ -1,4 +1,4 @@
-# Spring® Boot 2 Stack
+# Spring® Boot 2 Stack 
 
 The Spring Boot 2 stack supports the development of [Spring Boot 2](https://spring.io/projects/spring-boot) applications using OpenJDK 8 and OpenJ9 from [AdoptOpenJDK](https://adoptopenjdk.net/).
 

--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -1,10 +1,8 @@
-FROM kabanero/ubi8-maven:0.3.0
+FROM {{.stack.baseimage}}
 
-LABEL vendor="Kabanero" \
-    name="kabanero/java-spring-boot2" \
-    version="0.2.10" \
-    summary="Image for Kabanero java-spring-boot2 development" \
-    description="This image contains the Kabanero development stack for the java-spring-boot2 collection"
+# Ensure up to date / patched OS
+COPY ./project/update.sh /update.sh
+RUN  /update.sh --system
 
 RUN groupadd --gid 1000 java_group \
  && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user \

--- a/incubator/java-spring-boot2/image/project/.appsody-init.bat
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.bat
@@ -9,6 +9,6 @@ robocopy .mvn ..\.mvn /e /njh /njs /ndl /nc /ns >nul
 where java >nul 2>nul
 if %ERRORLEVEL% EQU 0 (
   if defined JAVA_HOME (
-    ..\mvnw install -q -f ./appsody-boot2-pom.xml
+    ..\mvnw install -q -f ./{{.stack.parentpomfilename}}
   )
 )

--- a/incubator/java-spring-boot2/image/project/.appsody-init.sh
+++ b/incubator/java-spring-boot2/image/project/.appsody-init.sh
@@ -20,7 +20,7 @@ fi
 
 which java 2>&1 >/dev/null ; JAVA_KNOWN=$?
 if [ ! -z "$JAVA_HOME" ] || [ $JAVA_KNOWN = "0" ]; then
-  ./mvnw install -q -f ./appsody-boot2-pom.xml
+  ./mvnw install -q -f ./{{.stack.parentpomfilename}}
 fi
 
 # copy the maven wrapper from the stack to extracted application directory

--- a/incubator/java-spring-boot2/image/project/Dockerfile
+++ b/incubator/java-spring-boot2/image/project/Dockerfile
@@ -1,17 +1,30 @@
-FROM kabanero/ubi8-maven:0.3.0 as compile
+############################################################################
+# 
+# Prepare stable image layers to be cached and reused below, as referenced
+# via "--from=compile".
+#
+FROM {{.stack.baseimage}} as compile
+
+USER root
+
+# Ensure up to date / patched OS
+COPY ./update.sh /update.sh
+RUN  /update.sh
 
 RUN  groupadd --gid 1000 java_group \
   && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user \
   && mkdir -p /mvn/repository \
   && chown -R java_user:java_group /mvn
 
-#setup project folder for java build step
 USER java_user
 
+# Labels for Intermediate image used for layer caching
+LABEL "stack.appsody.dev/id"="{{.stack.image.namespace}}/{{.stack.id}}"
+LABEL "stack.appsody.dev/version"="{{.stack.semver.major}}.{{.stack.semver.minor}}.{{.stack.semver.patch}}"
+
 # Layer caching for stack dependencies
-LABEL appsody.stack={{.stack.image.namespace}}/{{.stack.id}}:{{.stack.semver.major}}.{{.stack.semver.minor}}.{{.stack.semver.patch}}
-COPY --chown=java_user:java_group appsody-boot2-pom.xml /mvn/appsody-boot2-pom.xml
-RUN mvn --no-transfer-progress -B dependency:go-offline install -f /mvn/appsody-boot2-pom.xml
+COPY --chown=java_user:java_group {{.stack.parentpomfilename}} /mvn/{{.stack.parentpomfilename}}
+RUN mvn --no-transfer-progress -B dependency:go-offline install -f /mvn/{{.stack.parentpomfilename}}
 
 # Layer caching for application dependencies
 COPY --chown=java_user:java_group user-app/pom.xml /mvn/pom.xml
@@ -26,26 +39,24 @@ RUN /project/util/check_version build \
  && /project/java-spring-boot2-build.sh package \
  && /project/java-spring-boot2-build.sh createStartScript
 
-### Base image for app.
+############################################################################
+# 
+# Begin build of final application image
+#
+FROM {{.stack.finalimage}}
 
-### Red Hat Runtime image based on RHEL. Requires subscription.
-## Requires Auth
-## FROM registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.7
-## Unauthed as per https://access.redhat.com/containers/?tab=images&get-method=unauthenticated#/registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
-#FROM registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.7
-
-FROM kabanero/ubi8-openjdk:0.3.0
+USER root
 
 RUN groupadd --gid 1000 java_group \
  && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user
 
-ARG artifactId=appsody-spring
-ARG version=1.0-SNAPSHOT
+USER java_user
+
 ENV JVM_ARGS=""
 
+# Need to find a way to pass version in during appsody build, from the application project source
+ARG version=1.0-SNAPSHOT
 LABEL org.opencontainers.image.version="${version}"
-LABEL org.opencontainers.image.title="${artifactId}"
-LABEL appsody.stack={{.stack.image.namespace}}/{{.stack.id}}:{{.stack.semver.major}}.{{.stack.semver.minor}}.{{.stack.semver.patch}}
 
 COPY --chown=java_user:java_group --from=compile /project/user-app/target/start.sh /start.sh
 
@@ -53,8 +64,6 @@ ARG DEPENDENCY=/project/user-app/target/dependency
 COPY --chown=java_user:java_group --from=compile ${DEPENDENCY}/BOOT-INF/lib /app/lib
 COPY --chown=java_user:java_group --from=compile ${DEPENDENCY}/META-INF /app/META-INF
 COPY --chown=java_user:java_group --from=compile ${DEPENDENCY}/BOOT-INF/classes /app
-
-USER java_user
 
 EXPOSE 8080
 EXPOSE 8443

--- a/incubator/java-spring-boot2/image/project/appsody-boot2-snowdrop-pom.xml
+++ b/incubator/java-spring-boot2/image/project/appsody-boot2-snowdrop-pom.xml
@@ -9,7 +9,7 @@
   <packaging>pom</packaging>
 
   <name>Appsody Spring Boot2 stack</name>
-  <description>Parent POM file for an AppsodyApplication project to facilitate usage of Spring Boot.</description>
+  <description>Parent POM file for an AppsodyApplication project to facilitate usage of Spring Boot with Snowdrop.</description>
   <url>https://appsody.dev</url>
 
   <licenses>
@@ -19,6 +19,32 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <repositories>
+    <repository>
+      <id>redhat-early-access</id>
+      <name>Red Hat Early Access Repository</name>
+      <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
+    </repository>
+    <repository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>redhat-early-access</id>
+      <name>Red Hat Early Access Repository</name>
+      <url>https://maven.repository.redhat.com/earlyaccess/all/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>redhat-ga</id>
+      <name>Red Hat GA Repository</name>
+      <url>https://maven.repository.redhat.com/ga/</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <!-- order of precedence of the artifact’s version is:
     * The version of the artifact’s direct declaration in project pom
@@ -30,30 +56,57 @@
       then the version in the BOM file that was declared first will win
   -->
 
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-dependencies</artifactId>
-    <version>2.1.6.RELEASE</version>
-  </parent>
-
   <properties>
     <!-- Required library versions -->
+    <spring-boot-bom.version>2.1.6.SP3-redhat-00001</spring-boot-bom.version>
     <spring-boot.version>2.1.6.RELEASE</spring-boot.version>
+
     <opentracing-spring-jaeger-web-starter.version>2.0.0</opentracing-spring-jaeger-web-starter.version>
 
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
+    <kotlin.version>1.2.71</kotlin.version>
     <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+    <!-- properties imported from spring-boot-dependencies for ${spring-boot.version} 
+         stack build process will test and ensure these remain in sync. -->
+		<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
+		<maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
+		<maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+		<maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+		<maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+		<maven-install-plugin.version>2.5.2</maven-install-plugin.version>
+		<maven-invoker-plugin.version>3.1.0</maven-invoker-plugin.version>
+		<maven-help-plugin.version>3.1.1</maven-help-plugin.version>
+		<maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+		<maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
+		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+		<maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
+		<maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-war-plugin.version>3.2.3</maven-war-plugin.version>    
+     
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <!-- required dependency versions -->
+      <dependency>
+        <groupId>me.snowdrop</groupId>
+        <artifactId>spring-boot-bom</artifactId>
+        <version>${spring-boot-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>      
     </dependencies>
   </dependencyManagement>
 

--- a/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
+++ b/incubator/java-spring-boot2/image/project/java-spring-boot2-build.sh
@@ -65,10 +65,10 @@ common() {
     exit 1
   fi
 
-  # Get parent pom information (appsody-boot2-pom.xml)
-  local a_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:groupId" /project/appsody-boot2-pom.xml)
-  local a_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:artifactId" /project/appsody-boot2-pom.xml)
-  local a_version=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:version" /project/appsody-boot2-pom.xml)
+  # Get parent pom information 
+  local a_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:groupId" /project/{{.stack.parentpomfilename}})
+  local a_artifactId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:artifactId" /project/{{.stack.parentpomfilename}})
+  local a_version=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:version" /project/{{.stack.parentpomfilename}})
   local a_major=$(echo ${a_version} | cut -d'.' -f1)
   local a_minor=$(echo ${a_version} | cut -d'.' -f2)
   ((next=a_minor+1))
@@ -78,7 +78,12 @@ common() {
   then
     # Install parent pom
     note "Installing parent ${a_groupId}:${a_artifactId}:${a_version} and required dependencies..."
-    run_mvn install -q -f /project/appsody-boot2-pom.xml
+    if [ -z "${APPSODY_DEV_MODE}" ]
+    then
+      run_mvn install -q -f /project/{{.stack.parentpomfilename}}
+    else
+      run_mvn install -f /project/{{.stack.parentpomfilename}}
+    fi
   fi
 
   local p_groupId=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:parent/x:groupId" pom.xml)
@@ -119,7 +124,7 @@ the parent version in pom.xml, and test your changes.
 
 recompile() {
   note "Compile project in the foreground"
-  exec_run_mvn compile
+  exec_run_mvn compile 
 }
 
 package() {

--- a/incubator/java-spring-boot2/image/project/update.sh
+++ b/incubator/java-spring-boot2/image/project/update.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This is the list of packages that are required for stack operation and may not be present
+# in the base image. 
+XTRAPKGS="curl wget xmlstarlet unzip ca-certificates"
+
+UPDATE_SYSTEM=false
+
+#
+# Check for optional parameter indicating "update the system"
+#
+OPTS=`getopt -o s --long system -- "$@"`
+[ $? != 0 ] && echo "ERROR Invalid parameter." >&2 && exit 1
+
+eval set -- "$OPTS"
+
+while true; do
+  case "$1" in
+    -s | --system ) UPDATE_SYSTEM=true; shift ;;
+    -- ) shift; break ;;
+    * ) echo "ERROR Invalid option \"$1\""; exit 1 ;;
+  esac
+done
+
+echo UPDATE_SYSTEM=$UPDATE_SYSTEM
+
+
+# 
+# Do Debian or Red Hat
+# 
+which apt-get 2>&1 > /dev/null; USINGAPT=$?
+if [ $USINGAPT = "0" ] ; then 
+	apt-get -qq update || exit 1
+	apt-get -qq install -y bash $XTRAPKGS || exit 1
+	
+	if [ $UPDATE_SYSTEM = "true" ]; then
+      export DEBIAN_FRONTEND=noninteractive
+	  apt-get -qq upgrade -y || exit 1
+	fi
+	
+	apt-get -qq clean \
+	  && rm -rf /tmp/* /var/lib/apt/lists/*
+else
+	EPEL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+	yum install --disableplugin=subscription-manager -y $EPEL || exit 1
+	yum install --disableplugin=subscription-manager -y $XTRAPKGS || exit 1	   
+
+	if [ $UPDATE_SYSTEM = "true" ]; then
+	  yum upgrade --disableplugin=subscription-manager -y || exit 1
+	fi
+
+	yum clean --disableplugin=subscription-manager packages 	
+fi  

--- a/incubator/java-spring-boot2/image/project/util/check_version
+++ b/incubator/java-spring-boot2/image/project/util/check_version
@@ -12,6 +12,13 @@ else
     shift
 fi
 
+download() {
+    if ! wget -nv https://repo1.maven.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar; then
+        echo "Version range validation utility: unable to download org.osgi.core-6.0.0.jar"
+        exit 1
+    fi
+}
+
 range_check() {
     java -cp .:org.osgi.core-6.0.0.jar RangeIncludesVersion "$1" "$2"
     return $?
@@ -20,19 +27,22 @@ range_check() {
 sniff() {
     range_check "$1" "$2"
     if [ $? -ne $3 ]; then
-        echo "Test |'$1' contains '$2'| should return $3. Got $?"
+        echo "Version range validation utility: Test |'$1' contains '$2'| should return $3. Got $?"
         exit 1
     fi
 }
 
 case "$ACTION" in
   build)
-    wget -q https://repo1.maven.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.jar
-    javac -cp org.osgi.core-6.0.0.jar *.java
+    download
 
+    echo "Version range validation utility: build"
+    javac -cp org.osgi.core-6.0.0.jar *.java
+    echo "Version range validation utility: test"
     sniff "[0.3,0.4)" "0.3.7" 0
     sniff "[0.3,0.4)" "0.4" 1
     sniff "[0.3,0.4)" "0.2" 1
+    echo "Version range validation utility: done"
     exit 0
   ;;
   contains)

--- a/incubator/java-spring-boot2/image/project/verify-property-versions.sh
+++ b/incubator/java-spring-boot2/image/project/verify-property-versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Where is the parent pom located?
-PARENT_POM=/project/appsody-boot2-pom.xml
+PARENT_POM=/project/{{.stack.parentpomfilename}}
 
 # Read the Spring boot version from our parent pom
 SPRING_BOOT_VERSION=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:properties/x:spring-boot.version" $PARENT_POM)
@@ -16,7 +16,7 @@ xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -m "/x:project/x:p
 grep -Fxf /tmp/springprops /tmp/parentprops > /tmp/matchingprops
 
 RC=0
-# Compare the value of interesected property names, report mismatches.
+# Compare the value of intersected property names, report mismatches.
 for prop in $(cat /tmp/matchingprops); do
   echo -n "Evaluating $prop "
   PARENTVER=$(xmlstarlet sel -T -N x="http://maven.apache.org/POM/4.0.0" -t -v "/x:project/x:properties/x:$prop" $PARENT_POM)

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.21
+version: 0.3.23
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java
@@ -15,7 +15,9 @@ requirements:
    appsody-version: ">= 0.5.0"
    docker-version: ">= 17.09.0"
 templating-data:
+  baseimage: kabanero/ubi8-maven:0.3.0
+  finalimage: adoptopenjdk/openjdk8-openj9:ubi-jre
   parentpomgroup: dev.appsody
-  parentpomid: spring-boot2-stack
+  parentpomid: spring-boot2-stack-snowdrop
   parentpomrange: '[0.3, 0.4)'
-
+  parentpomfilename: appsody-boot2-snowdrop-pom.xml

--- a/incubator/java-spring-boot2/templates/default/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2/templates/default/src/main/resources/application.properties
@@ -1,5 +1,3 @@
 #enable the actuator endpoints for health, metrics, and prometheus.
 management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
-spring.devtools.restart.additional-paths=./target
-spring.devtools.restart.trigger-file=.appsody-spring-trigger
 opentracing.jaeger.log-spans = false

--- a/incubator/java-spring-boot2/templates/kotlin/src/main/resources/application.properties
+++ b/incubator/java-spring-boot2/templates/kotlin/src/main/resources/application.properties
@@ -1,5 +1,3 @@
 #enable the actuator endpoints for health, metrics, and prometheus.
 management.endpoints.web.exposure.include=health,metrics,prometheus,liveness
-spring.devtools.restart.additional-paths=./target
-spring.devtools.restart.trigger-file=.appsody-spring-trigger
 opentracing.jaeger.log-spans = false


### PR DESCRIPTION
### Checklist:

- [X ] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [ X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Introduces a parent pom for spring boot apps using snowdrop dependency management. 
Add new README section explaining new stack variables baseimage and finalimage. 
Re-align kabanero spring boot stack with upstream appsody stack.
Switch application image from "kabanero/ubi8-openjdk:0.3.0" to "adoptopenjdk/openjdk8-openj9:ubi-jre".

### Related Issues:
Spring stacks (appsody and kab) should move to adoptopenjdk/ubi
https://github.ibm.com/ibmcloud/spring-at-ibm/issues/131