### PR TITLE
java-microprofile: Upgrade OL version

### DIFF
--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -25,9 +25,8 @@ RUN cd /project/user-app/target && \
     mv wlp/usr/servers/*/* /config/
 
 # Step 2: Package Open Liberty image
-FROM openliberty/open-liberty:19.0.0.9-microProfile3-ubi-min
+FROM openliberty/open-liberty:{{.stack.libertyversion}}-kernel-java8-openj9-ubi
 
 COPY --chown=1001:0 --from=0 /config/ /opt/ol/wlp/usr/servers/defaultServer/
 
-EXPOSE 9080
-EXPOSE 9443
+RUN configure.sh

--- a/incubator/java-microprofile/image/project/pom.xml
+++ b/incubator/java-microprofile/image/project/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-microprofile</artifactId>
-    <version>0.2.21</version>
+    <version>0.2.23</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -30,7 +30,7 @@
         <!-- OpenLiberty runtime -->
         <liberty.groupId>io.openliberty</liberty.groupId>
         <liberty.artifactId>openliberty-runtime</liberty.artifactId>
-        <version.openliberty-runtime>19.0.0.9</version.openliberty-runtime>
+        <version.openliberty-runtime>{{.stack.libertyversion}}</version.openliberty-runtime>
         <http.port>9080</http.port>
         <https.port>9443</https.port>
         <packaging.type>usr</packaging.type>
@@ -66,8 +66,8 @@
                             </requireJavaVersion>
                             <requireProperty>
                                 <property>version.openliberty-runtime</property>
-                                <regex>19.0.0.9</regex>
-                                <regexMessage>OpenLiberty runtime version must be 19.0.0.9</regexMessage>
+                                <regex>{{.stack.libertyversion}}</regex>
+                                <regexMessage>OpenLiberty runtime version must be {{.stack.libertyversion}}</regexMessage>
                             </requireProperty>
                         </rules>
                     </configuration>

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.21
+version: 0.2.23
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java
@@ -14,3 +14,7 @@ maintainers:
     email: ozzy@ca.ibm.com
     github-id: BarDweller
 default-template: default
+requirements:
+    appsody-version: ">= 0.5.0"
+templating-data:
+    libertyversion: '19.0.0.12' 


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections

Update the java-microprofile stack to use Open Liberty version 19.0.0.12
Use go template variable for the open liberty version

*Note:* This updates the stack version from 0.2.21 to 0.2.23. This is to keep the stacks between appsody and kabanero consistent, and since 0.2.22 was just an arbitrary version bump (see https://github.com/appsody/stacks/pull/643), this seems OK. 