### PR TITLE
java-microprofile: remove quickstart password

### DIFF
--- a/incubator/java-microprofile/README.md
+++ b/incubator/java-microprofile/README.md
@@ -29,7 +29,12 @@ The `mpMetrics` feature enables MicroProfile Metrics support in Open Liberty. No
 
 Metrics endpoint: http://localhost:9080/metrics
 
-Log in as the `admin` user with `adminpwd` as the password to see both the system and application metrics in a text format.
+The log in user is `admin` and the password is randomly generated at startup by Open Liberty. You can use the following command to retrieve the password from the container which is listed as the `keystore_password` variable:
+```bash
+docker exec -it <container_id>  bash -c "cat /project/user-app/target/liberty/wlp/usr/servers/defaultServer/server.env"
+```
+
+Once logged in, you can see both the system and application metrics in a text format.
 
 ### OpenAPI
 

--- a/incubator/java-microprofile/image/project/Dockerfile
+++ b/incubator/java-microprofile/image/project/Dockerfile
@@ -1,4 +1,4 @@
-FROM kabanero/ubi8-maven:0.3.1
+FROM kabanero/ubi8-maven:0.3.1 as compile
 
 RUN  groupadd java_group \
   && useradd --gid java_group --shell /bin/bash --create-home java_user \
@@ -25,8 +25,11 @@ RUN cd /project/user-app && mvn -B --no-transfer-progress package -Dskip=true -D
 RUN cd /project/user-app && mvn -B --no-transfer-progress liberty:install-server
 
 # Copy and build the application source
+# Remove quick-start-security.xml since it is only needed during local development.
 COPY --chown=java_user:java_group ./user-app/src /project/user-app/src
-RUN cd /project/user-app && mvn -B --no-transfer-progress package -DskipTests
+RUN cd /project/user-app && \
+    rm -f src/main/liberty/config/configDropins/defaults/quick-start-security.xml && \
+    mvn -B --no-transfer-progress package -DskipTests
 
 RUN cd /project/user-app/target && \
     unzip *.zip && \
@@ -35,6 +38,6 @@ RUN cd /project/user-app/target && \
 # Step 2: Package Open Liberty image
 FROM openliberty/open-liberty:{{.stack.libertyversion}}-kernel-java8-openj9-ubi
 
-COPY --chown=1001:0 --from=0 /config/ /opt/ol/wlp/usr/servers/defaultServer/
+COPY --chown=1001:0 --from=compile /config/ /opt/ol/wlp/usr/servers/defaultServer/
 
 RUN configure.sh

--- a/incubator/java-microprofile/image/project/pom.xml
+++ b/incubator/java-microprofile/image/project/pom.xml
@@ -8,13 +8,13 @@
     <parent>
         <groupId>net.wasdev.wlp.maven.parent</groupId>
         <artifactId>liberty-maven-app-parent</artifactId>
-        <version>2.6.4</version>
+        <version>2.7</version>
         <relativePath></relativePath>
     </parent>
 
     <groupId>dev.appsody</groupId>
     <artifactId>java-microprofile</artifactId>
-    <version>0.2.24</version>
+    <version>0.2.25</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -1,5 +1,5 @@
 name: Eclipse MicroProfile®
-version: 0.2.24
+version: 0.2.25
 description: Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven
 license: Apache-2.0
 language: java

--- a/incubator/java-microprofile/templates/default/src/main/liberty/config/configDropins/defaults/quick-start-security.xml
+++ b/incubator/java-microprofile/templates/default/src/main/liberty/config/configDropins/defaults/quick-start-security.xml
@@ -1,0 +1,3 @@
+<server>
+    <quickStartSecurity userName="admin" userPassword="${keystore_password}" />
+</server>

--- a/incubator/java-microprofile/templates/default/src/main/liberty/config/server.xml
+++ b/incubator/java-microprofile/templates/default/src/main/liberty/config/server.xml
@@ -2,8 +2,7 @@
     <featureManager>
         <feature>microProfile-3.0</feature>
     </featureManager>
-    <quickStartSecurity userName="admin" userPassword="adminpwd"/>
-    <keyStore id="defaultKeyStore" location="key.jks" type="jks" password="mpKeystore"/>
+    
     <httpEndpoint host="*" httpPort="${default.http.port}" 
         httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
     


### PR DESCRIPTION
This PR does not include a full write-up of a matching issue.   

The Open Liberty architecture team wants to provide a more secure default / out-of-box experience, and so asked us to remove default passwords and replace them with generated ones.    

At the same time we removed this configuration from the `appsody build` Dockerfile.

The README.md in stack was updated, and SVT was notified (didn't think there'd be an issue). 

In addition, we should, if feasible, look to update this collateral:
1. https://developer.ibm.com/components/open-liberty/tutorials/configure-an-observable-microservice-with-appsody-openshift-open-liberty
1. https://ibm-cloud-architecture.github.io/Learning-Kabanero-101/web/1.0.0/e2e-java-microprofile.html

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Remove quick start security password and default to auto-generated password.