### PR TITLE
bump maven container version

### DIFF
--- a/docker/image_build.sh
+++ b/docker/image_build.sh
@@ -2,4 +2,4 @@
 
 docker build -t kabanero/ubi8-openjdk -t kabanero/ubi8-openjdk:0.3.0 -f ./Dockerfile-ubi8-openJDK .
 
-docker build -t kabanero/ubi8-maven -t kabanero/ubi8-maven:0.3.0 -f ./Dockerfile-maven .
+docker build -t kabanero/ubi8-maven -t kabanero/ubi8-maven:0.3.1 -f ./Dockerfile-maven .


### PR DESCRIPTION
This PR bumps the version of the ubi-maven image to reflect the recent change in the docker file.