### PR TITLE
Revert -snowdrop parent pom id

### DIFF
--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.23
+version: 0.3.24
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java
@@ -18,6 +18,6 @@ templating-data:
   baseimage: kabanero/ubi8-maven:0.3.0
   finalimage: adoptopenjdk/openjdk8-openj9:ubi-jre
   parentpomgroup: dev.appsody
-  parentpomid: spring-boot2-stack-snowdrop
+  parentpomid: spring-boot2-stack
   parentpomrange: '[0.3, 0.4)'
   parentpomfilename: appsody-boot2-snowdrop-pom.xml


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Removes `-snowdrop` append applied to parentpom to make it unique for kabanero.

*SVT NOTE* any projects init'd with stack 0.3.23 will not function when this is delivered, that is expected, and intentional. 

### Related Issues:
Fixes #299 