### PR TITLE
Overwrite instead of append

### DIFF
--- a/ci/tekton/openshift.yaml
+++ b/ci/tekton/openshift.yaml
@@ -31,7 +31,7 @@ spec:
               if [ -z "$ROUTE" ]; then
                 sleep 1
               else
-                echo "http://$ROUTE" >> /usr/share/kabanero/route
+                echo "http://$ROUTE" > /usr/share/kabanero/route
                 exit 0
               fi
             done


### PR DESCRIPTION
### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
Overwrite the file with route information instead of appending to it. Container crash can cause the file to end up with two or more routes which breaks url replacement in nginx container.

### Related Issues:
None