### PR TITLE
retract spring boot stack image packages update

### DIFF
--- a/incubator/java-spring-boot2/README.md
+++ b/incubator/java-spring-boot2/README.md
@@ -75,7 +75,11 @@ The stack implementation provides for two Docker image specifications, as stack 
 
 The `finalimage` specification determines the image that will be used as the base for the application image. The `baseimage` is used as the base for the stack runtime (a development tool), and also for the "prep" stage of the application image build. By default, as shown above, a Debian image is used for `baseimage` and a Red Hat UBI image is used for `finalimage`. 
 
-The stack implementation provides for optionally updating the packages in these images during the Docker build. By default, the UBI base for the `finalimage` is not updated, while the stack image on the other hand does get updated during a build of the stack itself. 
+The stack implementation provides for optionally updating the packages in these images during the Docker build. By default, packages are not updated in either image. To "turn on" package update, modify the Dockerfile (or Dockerfile-stack) and add the `--system` option to the invocation of `update.sh`. 
+
+```
+RUN  /update.sh --system
+```
 
 For more information about UBI see:
 [Introducing the Red Hat Universal Base Image](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image)

--- a/incubator/java-spring-boot2/image/Dockerfile-stack
+++ b/incubator/java-spring-boot2/image/Dockerfile-stack
@@ -8,7 +8,7 @@ LABEL vendor="Kabanero" \
 
 # Ensure up to date / patched OS
 COPY ./project/update.sh /update.sh
-RUN  /update.sh --system
+RUN  /update.sh
 
 RUN groupadd --gid 1000 java_group \
  && useradd --uid 1000 --gid java_group --shell /bin/bash --create-home java_user \

--- a/incubator/java-spring-boot2/stack.yaml
+++ b/incubator/java-spring-boot2/stack.yaml
@@ -1,5 +1,5 @@
 name: Spring Boot®
-version: 0.3.27
+version: 0.3.28
 description: Spring Boot using OpenJ9 and Maven
 license: Apache-2.0
 language: java


### PR DESCRIPTION
### Checklist:

- [X] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [X] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
The stack image was previously setup to run `yum upgrade` by default. This is now unwanted, due to governance and support concerns. This change retracts that `yum upgrade`.

### Related Issues:
remove update of stack image and final image packages
https://github.ibm.com/ibmcloud/spring-at-ibm/issues/142