### PR TITLE
Add deprecation of java-microprofile stack to release 0.6

### DIFF
--- a/incubator/java-microprofile/README.md
+++ b/incubator/java-microprofile/README.md
@@ -1,4 +1,6 @@
-# Java MicroProfile Stack
+# Java MicroProfile Stack (DEPRECATED)
+
+## This stack has been deprecated! Please use the [Java Open Liberty](https://github.com/appsody/stacks/tree/master/incubator/java-openliberty) stack.
 
 The Java MicroProfile stack provides a consistent way of developing microservices based upon the [Eclipse MicroProfile specifications](https://microprofile.io). This stack lets you use [Maven](https://maven.apache.org) to develop applications for [Open Liberty](https://openliberty.io) runtime, that is running on OpenJDK with container-optimizations in OpenJ9.
 

--- a/incubator/java-microprofile/image/project/.appsody-init.bat
+++ b/incubator/java-microprofile/image/project/.appsody-init.bat
@@ -3,4 +3,4 @@ set JAVA_FOUND=0
 where java >nul 2>nul
 if %ERRORLEVEL% EQU 0 set JAVA_FOUND=1
 if defined JAVA_HOME set JAVA_FOUND=1
-if "%JAVA_FOUND%"==1 mvnw install -Denforcer.skip=true
+if "%JAVA_FOUND%"=="1" mvnw install -Denforcer.skip=true

--- a/incubator/java-microprofile/stack.yaml
+++ b/incubator/java-microprofile/stack.yaml
@@ -17,4 +17,5 @@ default-template: default
 requirements:
     appsody-version: ">= 0.5.0"
 templating-data:
-    libertyversion: '19.0.0.12' 
+    libertyversion: '19.0.0.12'
+deprecated: 04/20/2020 - This stack has been replaced by the Open Liberty stack (java-openliberty)


### PR DESCRIPTION
This PR deprecates the java-microprofile stack in the 0.6 release branch.