### PR TITLE
nodejs: Add 'build' and 'prune' lifecycle events

### DIFF
--- a/incubator/nodejs/README.md
+++ b/incubator/nodejs/README.md
@@ -40,6 +40,20 @@ Templates are used to create your local project and start your development. When
 
     **NOTE:** Currently the `appsody deploy` command only works for deploying web applications.
 
+## Customizing the build
+
+Simple Node projects do not require a 'build' process: they are executed directly from source.  However, some technologies such as Typescipt require commands to be invoked to prepare the project ready to be run.
+
+If your project's dependencies require an additional build step, you can do so as follows:
+
+- In your `package.json`, edit the `"scripts"` section and define two new scripts:
+  - `"build": "npm install && <build commands>"`
+  - `"prune": "<cleanup commands> && npm prune"`
+
+When initially launching your app using `appsody run`, or building the production image with `appsody build`, the 'build' script is executed (if one exists).  Your build script should invoke `npm install` if any dependencies specified in your `devDependencies` are required as part of the build process - such as command line tools.
+
+When generating the production image, the 'prune' script is executed after that, if it exists, and is run with the `--production` flag.  This allows the removal of development dependencies that were required during the 'build' step.  This could be as simple as running the `npm prune` command, which inherits the production flag, and restores the dependencies to a production state.  You may also use this step to clean up any build artifacts that are not necessary in your production image.
+
 ## License
 
 This stack is licensed under the [Apache 2.0](./image/LICENSE) license

--- a/incubator/nodejs/image/Dockerfile-stack
+++ b/incubator/nodejs/image/Dockerfile-stack
@@ -18,7 +18,7 @@ ENV APPSODY_WATCH_DIR=/project/user-app
 ENV APPSODY_WATCH_IGNORE_DIR=/project/user-app/node_modules
 ENV APPSODY_WATCH_REGEX="^.*.js$"
 
-ENV APPSODY_PREP="npm install"
+ENV APPSODY_PREP="npm install && npm run build --if-present"
 
 ENV APPSODY_RUN="npm start --node-options --require=appmetrics-dash/attach"
 ENV APPSODY_RUN_ON_CHANGE="npm start --node-options --require=appmetrics-dash/attach"

--- a/incubator/nodejs/image/project/Dockerfile
+++ b/incubator/nodejs/image/project/Dockerfile
@@ -3,7 +3,10 @@ FROM registry.access.redhat.com/ubi8/nodejs-12:1-36
 USER root
 
 # Install OS updates
-RUN useradd --uid 1000 --gid 0 --shell /bin/bash --create-home node
+RUN yum install --disableplugin=subscription-manager python2 openssl-devel -y \
+ && yum clean --disableplugin=subscription-manager packages \
+ && ln -s /usr/bin/python2 /usr/bin/python \
+ && useradd --uid 1000 --gid 0 --shell /bin/bash --create-home node
 
 COPY .* /project/
 COPY *.* /project/
@@ -14,7 +17,21 @@ COPY user-app /project/user-app/
 WORKDIR "/project/user-app"
 COPY ./user-app/package*.json ./
 
+# This stack includes two customization points that user projects can utilize if needed.
+
+# npm run build: Run a build phase. Projects that need to execute build commands can 
+# customize the 'build' script in their package.json. The build script should call
+# 'npm install' if any devDependencies are required at this stage.
+
+# npm run prune: Uninstall dev dependencies, leaving only production dependencies.
+# Projects can customize the 'prune' script in their package.json.
+# Ideally this would just be 'npm prune', but this command does not have pre/post
+# hooks. Instead, the user's 'prune' script can itself call 'npm prune' in addition
+# to any additional actions required.
+
 RUN npm install --production \
+ && npm run build --if-present \
+ && npm run prune --production --if-present \
  && chown -hR node:0 /project \
  && chmod -R g=u /project
 

--- a/incubator/nodejs/stack.yaml
+++ b/incubator/nodejs/stack.yaml
@@ -1,5 +1,5 @@
 name: Node.js
-version: 0.3.6
+version: 0.4.0
 description: Runtime for Node.js applications
 license: Apache-2.0
 language: nodejs


### PR DESCRIPTION
Equivalent of https://github.com/appsody/stacks/pull/841

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
<!--- Describe your changes in detail -->
I added `npm build` and `npm prune` steps to the build process for the production image, to provide a point of customization in cases where the project needs to perform build actions (such as running the Angular or Typescript compiler).

The 'prune' step is required to remove any development dependencies, and/or perform any cleanup of artifacts generated during the build, which would otherwise bloat the final image. 

Although there is an `npm prune` command, it does not behave the same way as `install`, `test` etc in that it does not invoke any scripts in package.json (none of `prune`, `preprune`, `postprune` are run).  The only way to run a script called `prune` is to run `npm run prune` (which is what I've gone for).  It is run with `--production` so that the user's script can invoke `npm prune` (possibly in addition to other actions), and this will have the effect of running `npm prune --production`, which removes any development-only dependencies.

I have added python to the production image as it is required to run `node-gyp`, used by some dependencies during their installation (such as `node-rdkafka`).  I also added `openssl-devel` as this is also required by `node-rdkafka` and is likely to be a fairly common requirement.  Both are already included in the `node-express` stack.

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->