### PR TITLE
use latest ubi images (12:1-59) for nodejs-express stack

### DIFF
--- a/incubator/nodejs-express/image/Dockerfile-stack
+++ b/incubator/nodejs-express/image/Dockerfile-stack
@@ -1,8 +1,8 @@
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-36
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-59
 
 LABEL vendor="Kabanero" \
     name="kabanero/nodejs-express" \
-    version="0.4.8" \
+    version="0.4.9" \
     summary="Image for Kabanero Node.js Express development" \
     description="This image contains the Kabanero development stack for the Nodejs Express collection"
 

--- a/incubator/nodejs-express/image/project/Dockerfile
+++ b/incubator/nodejs-express/image/project/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-36
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-59
 
 USER root
 

--- a/incubator/nodejs-express/image/project/package.json
+++ b/incubator/nodejs-express/image/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-express",
-  "version": "0.4.6",
+  "version": "0.4.9",
   "description": "Node.js Express Stack",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Signed-off-by: Gireesh Punathil <gpunathi@in.ibm.com>

### Checklist:

- [x] Read the [Code of Conduct](https://github.com/appsody/website/blob/master/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md).

- [x] Followed the [commit message guidelines](https://github.com/appsody/website/blob/master/CONTRIBUTING.md#commit-message-guidelines).


## Updates to the collections
<!--- Describe your changes in detail -->

### Related Issues:
<!-- e.g. Fixes #32, Related to #54, etc. -->

/cc @garypicher